### PR TITLE
feat: 添加对酷狗音乐的支持

### DIFF
--- a/src/main/java/top/gregtao/concerto/ConcertoClient.java
+++ b/src/main/java/top/gregtao/concerto/ConcertoClient.java
@@ -16,6 +16,7 @@ import top.gregtao.concerto.command.ShareMusicCommand;
 import top.gregtao.concerto.config.ClientConfig;
 import top.gregtao.concerto.config.ConfigFile;
 import top.gregtao.concerto.config.PresetPlaylistsConfig;
+import top.gregtao.concerto.http.kugou.KuGouMusicApiClient;
 import top.gregtao.concerto.http.netease.NeteaseCloudApiClient;
 import top.gregtao.concerto.http.qq.QQMusicApiClient;
 import top.gregtao.concerto.music.list.Playlist;
@@ -78,6 +79,20 @@ public class ConcertoClient implements ClientModInitializer {
                     PresetPlaylistsConfig.LOCAL_PLAYLISTS.read();
 					NeteaseCloudApiClient.LOCAL_USER.updateLoginStatus();
 					QQMusicApiClient.LOCAL_USER.updateLoginStatus();
+					KuGouMusicApiClient.LOCAL_USER.updateLoginStatus();
+					// 刷新 token, 延长 token 有效时间
+					KuGouMusicApiClient.INSTANCE.refreshToken();
+					// 更新 VIP 状态
+					KuGouMusicApiClient.LOCAL_USER.updateVIPStatus();
+					// 自动获取每日酷狗音乐 VIP
+					ClientConfig.ClientConfigOptions options = ClientConfig.INSTANCE.options;
+					if (
+							options.kuGouMusicLite
+							&& KuGouMusicApiClient.LOCAL_USER.isLoggedIn()
+							&& options.autoGetKuGouDailyVIP
+					) {
+						KuGouMusicApiClient.INSTANCE.receiveVip();
+					}
 				});
 			}
 		});

--- a/src/main/java/top/gregtao/concerto/ConcertoServer.java
+++ b/src/main/java/top/gregtao/concerto/ConcertoServer.java
@@ -1,17 +1,21 @@
 package top.gregtao.concerto;
 
+import net.fabricmc.api.EnvType;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
 import net.fabricmc.fabric.api.resource.SimpleSynchronousResourceReloadListener;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.resource.ResourceManager;
 import net.minecraft.resource.ResourceType;
 import net.minecraft.util.Identifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import top.gregtao.concerto.command.ConcertoServerCommand;
+import top.gregtao.concerto.config.ClientConfig;
 import top.gregtao.concerto.config.PresetPlaylistsConfig;
 import top.gregtao.concerto.config.ServerConfig;
+import top.gregtao.concerto.http.kugou.KuGouMusicApiClient;
 import top.gregtao.concerto.http.netease.NeteaseCloudApiClient;
 import top.gregtao.concerto.http.qq.QQMusicApiClient;
 import top.gregtao.concerto.network.ConcertoNetworking;
@@ -42,8 +46,13 @@ public class ConcertoServer implements ModInitializer {
 
     public static void reload() {
         ServerConfig.INSTANCE.readOptions();
+        if (FabricLoader.getInstance().getEnvironmentType() == EnvType.SERVER) {
+            // 只在专用服务器同步配置
+            ClientConfig.INSTANCE.options.kuGouMusicLite = ServerConfig.INSTANCE.options.kuGouMusicLite;
+        }
         PresetPlaylistsConfig.PRESET_RADIOS.read();
         NeteaseCloudApiClient.INSTANCE.readCookie();
         QQMusicApiClient.INSTANCE.readCookie();
+        KuGouMusicApiClient.INSTANCE.readCookie();
     }
 }

--- a/src/main/java/top/gregtao/concerto/api/MusicJsonParsers.java
+++ b/src/main/java/top/gregtao/concerto/api/MusicJsonParsers.java
@@ -47,6 +47,8 @@ public class MusicJsonParsers {
 
     public static final JsonParser<Music> QQ_MUSIC = registerMusicParser(new QQMusicJsonParser());
 
+    public static final JsonParser<Music> KUGOU_MUSIC = registerMusicParser(new KuGouMusicJsonParser());
+
     public static final JsonParser<Music> BILIBILI = registerMusicParser(new BilibiliMusicJsonParser());
 
     public static final JsonParser<Music> SHARED = registerMusicParser(new SharedMusicJsonParser());

--- a/src/main/java/top/gregtao/concerto/command/ConcertoServerCommand.java
+++ b/src/main/java/top/gregtao/concerto/command/ConcertoServerCommand.java
@@ -11,6 +11,7 @@ import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import top.gregtao.concerto.ConcertoServer;
 import top.gregtao.concerto.config.CacheManager;
+import top.gregtao.concerto.http.kugou.KuGouMusicApiClient;
 import top.gregtao.concerto.http.netease.NeteaseCloudApiClient;
 import top.gregtao.concerto.http.qq.QQMusicApiClient;
 import top.gregtao.concerto.network.MusicDataPacket;
@@ -82,6 +83,7 @@ public class ConcertoServerCommand {
                                 .executes(context -> {
                                     NeteaseCloudApiClient.INSTANCE.readCookie();
                                     QQMusicApiClient.INSTANCE.readCookie();
+                                    KuGouMusicApiClient.INSTANCE.readCookie();
                                     return 0;
                                 })
                 ).then(

--- a/src/main/java/top/gregtao/concerto/config/ClientConfig.java
+++ b/src/main/java/top/gregtao/concerto/config/ClientConfig.java
@@ -97,6 +97,12 @@ public class ClientConfig extends ConfigFile {
 
         public boolean textShadow = true;
         public boolean handshakeRequired = true;
+
+        // 是否为概念版
+        public boolean kuGouMusicLite = false;
+
+        // 是否自动领取酷狗每日VIP
+        public boolean autoGetKuGouDailyVIP = false;
     }
 
     public static class PositionXYSupplier {

--- a/src/main/java/top/gregtao/concerto/config/ServerConfig.java
+++ b/src/main/java/top/gregtao/concerto/config/ServerConfig.java
@@ -29,5 +29,6 @@ public class ServerConfig extends ConfigFile {
         public int musicRoomCommandPermission = 2;
         public int musicAgentAddTimeLimit = 60;
         public boolean musicAgentUseShared = true;
+        public boolean kuGouMusicLite = false;
     }
 }

--- a/src/main/java/top/gregtao/concerto/enums/SearchType.java
+++ b/src/main/java/top/gregtao/concerto/enums/SearchType.java
@@ -5,17 +5,19 @@ import top.gregtao.concerto.api.SimpleStringIdentifiable;
 
 public enum SearchType implements SimpleStringIdentifiable {
     // 网易云 1: 单曲, 10: 专辑, 100: 歌手, 1000: 歌单, 1002: 用户, 1004: MV, 1006: 歌词, 1009: 电台, 1014: 视频
-    MUSIC(1, 0, "song"),
-    ALBUM(10, 2, "album"),
-    PLAYLIST(1000, 3, "playlist");
+    MUSIC(1, 0, "song", "song"),
+    ALBUM(10, 2, "album", "album"),
+    PLAYLIST(1000, 3, "playlist", "special");
 
     public final int neteaseKey, qqKey;
     public final String qqSuffix;
+    public final String kuGouKey;
 
-    SearchType(int neteaseKey, int qqKey, String qqSuffix) {
+    SearchType(int neteaseKey, int qqKey, String qqSuffix, String kuGouKey) {
         this.neteaseKey = neteaseKey;
         this.qqKey = qqKey;
         this.qqSuffix = qqSuffix;
+        this.kuGouKey = kuGouKey;
     }
 
     public Text getName() {

--- a/src/main/java/top/gregtao/concerto/enums/Sources.java
+++ b/src/main/java/top/gregtao/concerto/enums/Sources.java
@@ -8,6 +8,7 @@ public enum Sources implements SimpleStringIdentifiable {
     INTERNET,
     NETEASE_CLOUD,
     QQ_MUSIC,
+    KUGOU_MUSIC,
     BILIBILI,
     SHARED
     ;

--- a/src/main/java/top/gregtao/concerto/http/kugou/KuGouMusicApiClient.java
+++ b/src/main/java/top/gregtao/concerto/http/kugou/KuGouMusicApiClient.java
@@ -1,0 +1,985 @@
+package top.gregtao.concerto.http.kugou;
+
+import com.google.gson.*;
+import org.apache.commons.lang3.StringUtils;
+import top.gregtao.concerto.ConcertoClient;
+import top.gregtao.concerto.config.ClientConfig;
+import top.gregtao.concerto.enums.SearchType;
+import top.gregtao.concerto.enums.Sources;
+import top.gregtao.concerto.http.HttpApiClient;
+import top.gregtao.concerto.http.HttpRequestBuilder;
+import top.gregtao.concerto.music.KuGouMusic;
+import top.gregtao.concerto.music.Music;
+import top.gregtao.concerto.music.list.KuGouMusicPlaylist;
+import top.gregtao.concerto.music.meta.music.MusicMetaData;
+import top.gregtao.concerto.music.meta.music.UnknownMusicMeta;
+import top.gregtao.concerto.music.meta.music.list.PlaylistMetaData;
+import top.gregtao.concerto.player.MusicPlayerHandler;
+import top.gregtao.concerto.util.*;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URLEncoder;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * 酷狗 API 来自 <a href="https://github.com/MakcRe/KuGouMusicApi">MakcRe/KuGouMusicApi</a>
+ */
+public class KuGouMusicApiClient extends HttpApiClient {
+
+    public static final Gson GSON = new GsonBuilder()
+            .enableComplexMapKeySerialization()
+            .create();
+
+    public static final String BASE_URL = "https://gateway.kugou.com";
+
+    public static final String LITE_APPID = "3116";
+
+    public static final String APPID = "1005";
+
+    public static final String LITE_CLIENT_VER = "11040";
+
+    public static final String CLIENT_VER = "12569";
+
+    public static final String KEY = "90b8382a1bb4ccdcf063102053fd75b8";
+
+    public static final String IV = "f063102053fd75b8";
+
+    public static final String LITE_KEY = "c24f74ca2820225badc01946dba4fdf7";
+
+    public static final String LITE_IV = "adc01946dba4fdf7";
+
+    public static Map<String, String> HEADERS = Map.of(
+            "User-Agent", "Android15-1070-11083-46-0-DiscoveryDRADProtocol-wifi",
+            "Referer", ""
+    );
+
+    public static Map<String, String> COOKIES;
+
+    public static KuGouMusicApiClient INSTANCE = new KuGouMusicApiClient();
+
+    public static KuGouMusicUser LOCAL_USER = new KuGouMusicUser(INSTANCE);
+
+    public KuGouMusicApiClient() {
+        // 不直接使用 Cookies
+        super(Sources.KUGOU_MUSIC.asString(), HEADERS, Map.of("", List.of()));
+    }
+
+    public Map<String, String> parseCookies(String raw) {
+        String[] cookies = raw.split(";");
+        Map<String, String> result = new HashMap<>();
+        for (String cookie : cookies) {
+            String[] pair = cookie.split("=");
+            if (pair.length == 2) {
+                result.put(pair[0].trim(), pair[1].trim());
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public void clearCookie() {
+        COOKIES.clear();
+        writeCookie();
+    }
+
+    @Override
+    public void writeCookie() {
+        String cookies = TextUtil.toBase64("https://www.kugou.com") + ":"
+                + COOKIES.entrySet().stream()
+                    .map(entry -> entry.getKey() + "=" + entry.getValue())
+                    .reduce((a, b) -> a + "\n" + b)
+                    .map(TextUtil::toBase64)
+                    .orElse("");
+
+        getCookieFile().write(cookies);
+    }
+
+    @Override
+    public void readCookie() {
+        COOKIES = parseCookies(getCookieFile().readAsHeader());
+    }
+
+    @Override
+    public void setCookie(String url, String key, String value) throws IOException, URISyntaxException {
+        COOKIES.put(key, value);
+        writeCookie();
+    }
+
+    @Override
+    public void setCookies(String url, Map<String, String> cookies) throws IOException, URISyntaxException {
+        COOKIES.putAll(cookies);
+        writeCookie();
+    }
+
+    public HttpResponse<String> request(String url, Map<String, String> params, KuGouRequestConfig config) {
+        boolean isLite = ClientConfig.INSTANCE.options.kuGouMusicLite;
+        String dfid = COOKIES.getOrDefault("dfid", "-");
+        String mid = HashUtil.md5(dfid);
+        String uuid = HashUtil.md5(dfid + mid);
+        String token = COOKIES.getOrDefault("token", "");
+        String userid = COOKIES.getOrDefault("userid", "0");
+        String clientTime = String.valueOf((long)(Math.floor((double) System.currentTimeMillis() / 1000)));
+        Map<String, String> paramsMap = new HashMap<>(params);
+        Map<String, String> headers = new HashMap<>(Map.of(
+                "dfid", dfid,
+                "mid", mid,
+                "clienttime", clientTime
+        ));
+
+        String appid = isLite ? LITE_APPID : APPID;
+        String clientVer = isLite ? LITE_CLIENT_VER : CLIENT_VER;
+        Map<String, String> defaultParams = new HashMap<>(Map.of(
+                "dfid", dfid,
+                "mid", mid,
+                "uuid", uuid,
+                "appid", appid,
+                "clientver", clientVer,
+                "userid", userid,
+                "clienttime", clientTime
+        ));
+
+        if (!StringUtils.isEmpty(token)) {
+            defaultParams.put("token", token);
+        }
+
+        if (!config.isClearDefaultParams()) {
+            paramsMap.putAll(defaultParams);
+        }
+
+        // 生成 Key
+        if (config.isNeedKey()) {
+            String key = KuGouMusicApiCrypto.signKey(
+                    paramsMap.getOrDefault("hash", ""),
+                    mid,
+                    userid,
+                    appid
+            );
+            paramsMap.put("key", key);
+        }
+
+        // 处理 data
+        Object data = config.getData();
+        String dataJson = data == null ? "" : GSON.toJson(data);
+
+        // 签名
+        if (!config.isNoSign()) {
+            String signature = "";
+            switch (config.getEncryptType()) {
+                case WEB -> signature = KuGouMusicApiCrypto.signWebParams(paramsMap);
+                case null, default -> signature = KuGouMusicApiCrypto.signAndroidParams(paramsMap, dataJson);
+            }
+            paramsMap.put("signature", signature);
+        }
+
+        String baseUrl = config.getBaseUrl();
+        String fullUrl = (baseUrl == null ? BASE_URL : baseUrl) + url;
+        if (!paramsMap.isEmpty()) {
+            fullUrl += paramsMap.entrySet().stream()
+                    .map(entry -> entry.getKey() + "=" + URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8))
+                    .reduce((a, b) -> a + "&" + b)
+                    .map(s -> "?" + s)
+                    .get();
+        }
+
+        headers.putAll(config.getHeaders());
+        HttpRequestBuilder builder = open().url(fullUrl).setHeaders(headers);
+        if (config.getRequestType().equals(KuGouRequestConfig.RequestType.GET)) {
+            return builder.get();
+        } else {
+            return builder.post(HttpResponse.BodyHandlers.ofString(), HttpRequestBuilder.ContentType.JSON,dataJson);
+        }
+    }
+
+    public Optional<JsonObject> search(String keyword, Integer page, SearchType searchType) {
+        Map<String, String> params = new HashMap<>(Map.of(
+                "albumhide", "0",
+                "iscorrection", "1",
+                "keyword", keyword,
+                "nocollect", "0",
+                "page", page.toString(),
+                "pagesize", "30",
+                "platform", "AndroidFilter"
+        ));
+        String url = "/" + (searchType.equals(SearchType.MUSIC) ? "v3" : "v1")
+                + "/search/" + searchType.kuGouKey;
+
+        JsonObject json = parseJson(request(
+                url,
+                params,
+                KuGouRequestConfig.builder()
+                        .addHeaders("x-router", "complexsearch.kugou.com")
+                        .build()
+        ));
+
+        return Optional.ofNullable(json);
+    }
+
+    public Optional<JsonObject> getSongUrl(String hash, boolean isFreePart) {
+        boolean isLite = ClientConfig.INSTANCE.options.kuGouMusicLite;
+        String pageId = isLite ? "967177915" : "151369488";
+        String ppageId = isLite ? "356753938,823673182,967485191" : "463467626,350369493,788954147";
+        String pid = isLite ? "411" : "2";
+
+        Map<String, String> params = new HashMap<>(){{
+            put("album_id", "0");
+            put("area_code", "1");
+            put("hash", hash);
+            put("ssa_flag", "is_fromtrack");
+            put("version", "11040");
+            put("page_id", pageId);
+            put("quality", "128");
+            put("album_audio_id", "0");
+            put("behavior", "play");
+            put("pid", pid);
+            put("cmd", "26");
+            put("pidversion", "3001");
+            put("IsFreePart", isFreePart ? "1" : "0");
+            put("ppage_id", ppageId);
+            put("cdnBackup", "1");
+            put("kcard", "0");
+            put("module", "");
+        }};
+
+        JsonObject json = parseJson(
+                request(
+                        "/v5/url",
+                        params,
+                        KuGouRequestConfig.builder()
+                                .needKey(true)
+                                .addHeaders("x-router", "trackercdn.kugou.com")
+                                .build()
+                )
+        );
+
+        return Optional.ofNullable(json);
+    }
+
+    public Optional<String> getMusicLink(String hash, boolean isFreePart) {
+        if (StringUtils.isEmpty(hash)) return Optional.empty();
+        return getSongUrl(hash, isFreePart)
+                .map(songUrlResponse -> songUrlResponse.getAsJsonArray("url"))
+                .map(url -> !url.isEmpty() ? url.get(0).getAsString() : null)
+                .map(link -> !link.isEmpty() ? link : null );
+    }
+
+    public Optional<JsonObject> getMusicHash(String hash) {
+        List<Map<String, String>> data = List.of(
+            Map.of(
+                    "type", "audio",
+                    "page_id", "0",
+                    "hash", hash,
+                    "album_id", "0"
+            )
+        );
+        String dfId = getCookie("dfid", "-");
+        String userId = getCookie("userid", "0");
+        String token = getCookie("token", "0");
+        String clientTime = getClientTime();
+
+        Map<String, Object> dataMap = Map.of(
+                "appid", getUseAppid(),
+                "clienttime", clientTime,
+                "clientver", getUseClientVer(),
+                "data", data,
+                "dfid", dfId,
+                "key", KuGouMusicApiCrypto.signParamsKey(clientTime),
+                "mid", HashUtil.md5(dfId),
+                "token", token,
+                "userid", userId
+        );
+
+        JsonObject json = parseJson(
+                request(
+                        "/v1/audio/audio",
+                        Map.of(),
+                        KuGouRequestConfig.builder()
+                                .baseUrl("http://kmr.service.kugou.com")
+                                .requestType(KuGouRequestConfig.RequestType.POST)
+                                .addHeaders("x-router", "media.store.kugou.com")
+                                .data(dataMap)
+                                .build()
+                )
+        );
+
+        return Optional.ofNullable(json);
+    }
+
+    public Optional<JsonObject> getMusicDetail(String albumAudioId, String field) {
+        if (StringUtils.isEmpty(albumAudioId)) return Optional.empty();
+        List<Object> data = List.of(
+                Map.of(
+                        "entity_id", Long.parseLong(albumAudioId)
+                )
+        );
+        Map<String, Object> dataMap = Map.of(
+                "data", data,
+                "fields", field
+        );
+
+        JsonObject json = parseJson(
+                request(
+                        "/kmr/v2/audio",
+                        Map.of(),
+                        KuGouRequestConfig.builder()
+                                .requestType(KuGouRequestConfig.RequestType.POST)
+                                .addHeaders("x-router", "openapi.kugou.com")
+                                .addHeaders("KG-TID", "238")
+                                .data(dataMap)
+                                .build()
+                )
+        );
+
+        if (json != null) {
+            JsonArray dataArray = json.getAsJsonArray("data");
+            if (dataArray != null && dataArray.size() > 0) {
+                return Optional.ofNullable(dataArray.get(0).getAsJsonObject());
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    public List<Music> searchMusic(String keyword, Integer page) {
+        JsonArray jsonArray = search(keyword, page, SearchType.MUSIC)
+                .map(json -> json.getAsJsonObject("data"))
+                .map(data -> data.getAsJsonArray("lists"))
+                .orElse(new JsonArray());
+        try {
+            return jsonArray.asList().stream()
+                    .map(element -> new KuGouMusic(element.getAsJsonObject()))
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            ConcertoClient.LOGGER.warn("Error while searching for music '{}': {}", keyword, e.getMessage());
+            return List.of();
+        }
+    }
+
+    public List<KuGouMusicPlaylist> searchPlaylist(String keyword, int page) {
+        JsonArray jsonArray = search(keyword, page, SearchType.PLAYLIST)
+                .map(json -> json.getAsJsonObject("data"))
+                .map(data -> data.getAsJsonArray("lists"))
+                .orElse(new JsonArray());
+
+        try {
+            return jsonArray.asList().stream()
+                    .map(element -> new KuGouMusicPlaylist(element.getAsJsonObject(), false, false))
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            ConcertoClient.LOGGER.warn("Error while searching for playlist '{}': {}", keyword, e.getMessage());
+            return new ArrayList<>();
+        }
+    }
+
+    public List<KuGouMusicPlaylist> searchAlbum(String keyword, int page) {
+        JsonArray jsonArray = search(keyword, page, SearchType.ALBUM)
+                .map(json -> json.getAsJsonObject("data"))
+                .map(data -> data.getAsJsonArray("lists"))
+                .orElse(new JsonArray());
+
+        try {
+            return jsonArray.asList().stream()
+                    .map(element -> new KuGouMusicPlaylist(element.getAsJsonObject(), true, false))
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            ConcertoClient.LOGGER.warn("Error while searching for album '{}': {}", keyword, e.getMessage());
+            return new ArrayList<>();
+        }
+    }
+
+    public Optional<JsonObject> getPlayListAllTrack(String id) {
+        if (StringUtils.isEmpty(id)) return Optional.empty();
+        Map<String, String> paramsMap = Map.of(
+                "area_code", "1",
+                "begin_idx", "0",
+                "plat", "1",
+                "type", "1",
+                "mode", "1",
+                "personal_switch", "1",
+                "extend_fields", "",
+                "pagesize", String.valueOf(MusicPlayerHandler.MAX_SIZE),
+                "global_collection_id", id
+        );
+
+        JsonObject json = parseJson(
+                request(
+                        "/pubsongs/v2/get_other_list_file_nofilt",
+                        paramsMap,
+                        KuGouRequestConfig.builder()
+                                .build()
+                )
+        );
+
+        return Optional.ofNullable(json);
+    }
+
+    public Pair<ArrayList<Music>, PlaylistMetaData> getPlaylist(String id) {
+        Optional<JsonObject> optional = getPlayListAllTrack(id);
+
+        Optional<JsonObject> data = optional.map(json -> json.getAsJsonObject("data"));
+        PlaylistMetaData playlistMetaData = data.map(json -> json.getAsJsonObject("list_info"))
+                .map(listInfoJson -> KuGouMusicPlaylist.parsePlaylistInfo(listInfoJson, true))
+                .orElse(PlaylistMetaData.EMPTY);
+
+        ArrayList<Music> songs = data.map(json -> json.getAsJsonArray("songs"))
+                .map(jsonElements -> jsonElements.asList().stream())
+                .map(stream -> stream.map(element -> (Music) new KuGouMusic(element.getAsJsonObject()))
+                        // 由于未知原因, 歌单里会有部分歌曲被 "保护", 无法被搜索和显示
+                        // 这里过滤掉这些歌曲
+                        .filter(music -> !(music.getMeta() instanceof UnknownMusicMeta))
+                        .collect(Collectors.toCollection(ArrayList::new))
+                )
+                .orElse(new ArrayList<>());
+
+        return Pair.of(songs, playlistMetaData);
+    }
+
+    public Optional<JsonObject> getAlbumDetail(String id) {
+        if (StringUtils.isEmpty(id)) return Optional.empty();
+        Map<String, Object> dataMap = Map.of(
+                "data", List.of(
+                        Map.of(
+                                "album_id", Long.parseLong(id)
+                        )
+                ),
+                "is_buy", 0,
+                "fields", "album_id,album_name,publish_date,sizable_cover,intro,authors"
+        );
+
+        JsonObject json = parseJson(
+                request(
+                        "/kmr/v2/albums",
+                        Map.of(),
+                        KuGouRequestConfig.builder()
+                                .requestType(KuGouRequestConfig.RequestType.POST)
+                                .data(dataMap)
+                                .addHeaders("x-router", "openapi.kugou.com")
+                                .addHeaders("kg-tid", "255")
+                                .build()
+                )
+        );
+
+        return Optional.ofNullable(json);
+    }
+
+    public Optional<JsonObject> getAlbumSongs(String id) {
+        if (StringUtils.isEmpty(id)) return Optional.empty();
+        Map<String, Object> dataMap = Map.of(
+                "album_id", id,
+                "is_buy", "",
+                "page", 1,
+                // 经测试, 最大值只能为 50
+                "pagesize", 50
+        );
+
+        JsonObject json = parseJson(
+                request(
+                        "/v1/album_audio/lite",
+                        Map.of(),
+                        KuGouRequestConfig.builder()
+                                .requestType(KuGouRequestConfig.RequestType.POST)
+                                .data(dataMap)
+                                .addHeaders("x-router", "openapi.kugou.com")
+                                .addHeaders("kg-tid", "255")
+                                .build()
+                )
+        );
+
+        return Optional.ofNullable(json);
+    }
+
+    public Pair<ArrayList<Music>, PlaylistMetaData> getAlbum(String id) {
+        Optional<JsonObject> albumDetail = getAlbumDetail(id);
+        Optional<JsonObject> albumSongs = getAlbumSongs(id);
+
+        PlaylistMetaData playlistMetaData = albumDetail.map(json -> json.getAsJsonArray("data"))
+                .map(arr -> !arr.isEmpty() ? arr.get(0).getAsJsonObject() : null)
+                .map(KuGouMusicPlaylist::parseAlbumInfo)
+                .orElse(PlaylistMetaData.EMPTY);
+
+        ArrayList<Music> songs = albumSongs.map(json -> json.getAsJsonObject("data"))
+                .map(data -> data.getAsJsonArray("songs"))
+                .map(arr -> arr.asList().stream()
+                        .map(element -> {
+                            Optional<JsonObject> songOpt = Optional.of(element.getAsJsonObject());
+
+                            String albumAudioId = songOpt.map(song -> song.getAsJsonObject("base"))
+                                    .map(base -> base.get("album_audio_id"))
+                                    .map(JsonElement::getAsString)
+                                    .orElse("");
+
+                            String hash = songOpt.map(song -> song.getAsJsonObject("audio_info"))
+                                    .map(audioInfo -> audioInfo.get("hash"))
+                                    .map(JsonElement::getAsString)
+                                    .orElse("");
+
+                            MusicMetaData musicMetaData = songOpt.map(KuGouMusic::parseMetaData)
+                                    .orElse(new UnknownMusicMeta(Sources.KUGOU_MUSIC.getName().getString()));
+
+                            return (Music) new KuGouMusic(musicMetaData, albumAudioId, hash);
+                        })
+                        .collect(Collectors.toCollection(ArrayList::new))
+                )
+                .orElse(new ArrayList<>());
+
+        return Pair.of(songs, playlistMetaData);
+    }
+
+    public Optional<JsonObject> getUserPlaylists(int page) {
+        String userId = getCookie("userid", "0");
+        String token = getCookie("token");
+        Map<String, Object> dataMap = Map.of(
+                "userid", userId,
+                "token", token,
+                "total_ver", 979,
+                "type", 2,
+                "page", page,
+                "pagesize", 30
+        );
+
+        Map<String, String> paramsMap = Map.of(
+                "plat", "1",
+                "userid", userId,
+                "token", token
+        );
+
+        return Optional.ofNullable(parseJson(
+                request(
+                        "/v7/get_all_list",
+                        paramsMap,
+                        KuGouRequestConfig.builder()
+                                .requestType(KuGouRequestConfig.RequestType.POST)
+                                .data(dataMap)
+                                .addHeaders("x-router", "cloudlist.service.kugou.com")
+                                .build()
+                )
+        ));
+    }
+
+    public Optional<JsonObject> getUserDetail() {
+        String userId = getCookie("userid", "0");
+        String token = getCookie("token");
+        long clientTime = Long.parseLong(getClientTime());
+        Map<String, Object> pMap = Map.of(
+                "token", token,
+                "clienttime", clientTime
+        );
+        String pk = KuGouMusicApiCrypto.cryptoRSAEncrypt(GSON.toJson(pMap)).toUpperCase();
+
+        Map<String, Object> dataMap = Map.of(
+                "visit_time", clientTime,
+                "usertype", 1,
+                "p", pk,
+                "userid", userId
+        );
+
+        JsonObject json = parseJson(
+                request(
+                        "/v3/get_my_info",
+                        Map.of(
+                                "plat", "1"
+                        ),
+                        KuGouRequestConfig.builder()
+                                .requestType(KuGouRequestConfig.RequestType.POST)
+                                .data(dataMap)
+                                .addHeaders("x-router", "usercenter.kugou.com")
+                                .build()
+                )
+        );
+
+        return Optional.ofNullable(json);
+    }
+
+    public String generateQRCodeKey() {
+        String qrUrl = "https://h5.kugou.com/apps/loginQRCode/html/index.html?appid=" + getUseAppid() + "&";
+        Map<String, String> paramsMap = Map.of(
+                "appid", "1001",
+                "type", "1",
+                "plat", "4",
+                "qrcode_txt", qrUrl,
+                "srcappid", "2919"
+        );
+
+        JsonObject json = parseJson(
+                request(
+                        "/v2/qrcode",
+                        paramsMap,
+                        KuGouRequestConfig.builder()
+                                .baseUrl("https://login-user.kugou.com")
+                                .requestType(KuGouRequestConfig.RequestType.GET)
+                                .encryptType(KuGouRequestConfig.EncryptType.WEB)
+                                .build()
+                )
+        );
+
+        Optional<JsonObject> optional = Optional.ofNullable(json);
+
+        return optional.map(object -> object.getAsJsonObject("data"))
+                .map(data -> data.get("qrcode"))
+                .map(JsonElement::getAsString)
+                .orElse("");
+    }
+
+    public Optional<JsonObject> getQRCodeStatus(String key) {
+        Map<String, String> paramsMap = Map.of(
+                "plat", "4",
+                "appid", "1001",
+                "srcappid", "2919",
+                "qrcode", key
+        );
+
+        JsonObject json = parseJson(
+                request(
+                        "/v2/get_userinfo_qrcode",
+                        paramsMap,
+                        KuGouRequestConfig.builder()
+                                .baseUrl("https://login-user.kugou.com")
+                                .requestType(KuGouRequestConfig.RequestType.GET)
+                                .encryptType(KuGouRequestConfig.EncryptType.WEB)
+                                .build()
+                )
+        );
+
+        return Optional.ofNullable(json);
+    }
+
+    public boolean sendPhoneCaptcha(String phone) {
+        if (StringUtils.isEmpty(phone)) return false;
+        Map<String, Object> dataMap = Map.of(
+                "businessid", 5,
+                "mobile", phone,
+                "plat", 3
+        );
+
+        JsonObject json = parseJson(
+                request(
+                        "/v7/send_mobile_code",
+                        Map.of(),
+                        KuGouRequestConfig.builder()
+                                .baseUrl("http://login.user.kugou.com")
+                                .requestType(KuGouRequestConfig.RequestType.POST)
+                                .data(dataMap)
+                                .build()
+                )
+        );
+
+        return json != null;
+    }
+
+    public Optional<Pair<Long, String>> cellphoneLogin(String mobile, String code) {
+        if (StringUtils.isEmpty(mobile) || StringUtils.isEmpty(code) || mobile.length() < 11) return Optional.empty();
+        long dateTime = System.currentTimeMillis();
+        Pair<String, String> encrypt = KuGouMusicApiCrypto.cryptoAesEncrypt(GSON.toJson(Map.of(
+                "mobile", mobile,
+                "code", code
+        )), null, null);
+        boolean isLite = ClientConfig.INSTANCE.options.kuGouMusicLite;
+
+        Map<String, Object> dataMap = new HashMap<>(Map.of(
+                "plat", 1,
+                "support_multi", 1,
+                "t1", 0,
+                "t2", 0,
+                "clienttime_ms", dateTime,
+                "mobile", mobile,
+                "key", KuGouMusicApiCrypto.signParamsKey(String.valueOf(dateTime))
+        ));
+
+        if (isLite) {
+            dataMap.put(
+                    "p2", KuGouMusicApiCrypto.cryptoRSAEncrypt(GSON.toJson(Map.of(
+                            "clienttime_ms", dateTime,
+                            "code", code,
+                            "mobile", mobile
+                    ))).toUpperCase()
+            );
+        } else {
+            String mobileStr = mobile.substring(0, 2) + "*****" + mobile.substring(10);
+            dataMap.put("mobile", mobileStr);
+            dataMap.put("t3", "MCwwLDAsMCwwLDAsMCwwLDA=");
+            dataMap.put("params", encrypt.getFirst());
+            dataMap.put("pk", KuGouMusicApiCrypto.cryptoRSAEncrypt(GSON.toJson(Map.of(
+                    "clienttime_ms", dateTime,
+                    "key", encrypt.getSecond()
+            ))).toUpperCase());
+        }
+
+        JsonObject json = parseJson(
+                request(
+                         "/" + (isLite ? "v6" : "v7") + "/login_by_verifycode",
+                        Map.of(),
+                        KuGouRequestConfig.builder()
+                                .requestType(KuGouRequestConfig.RequestType.POST)
+                                .data(dataMap)
+                                .addHeaders("x-router", "login.user.kugou.com")
+                                .build()
+                )
+        );
+
+        return getLoginData(json, encrypt.getSecond());
+    }
+
+    public Optional<Pair<Long, String>> login(String userName, String password) {
+        if (StringUtils.isEmpty(userName) || StringUtils.isEmpty(password)) return Optional.empty();
+        long dateNow = System.currentTimeMillis();
+        Pair<String, String> encrypt = KuGouMusicApiCrypto.cryptoAesEncrypt(GSON.toJson(Map.of(
+                "pwd", password,
+                "code", "",
+                "clienttime_ms", dateNow
+        )), null, null);
+
+        Map<String, Object> dataMap = new HashMap<>(Map.of(
+                "plat", 1,
+                "support_multi", 1,
+                "clienttime_ms", dateNow,
+                "t1", 0,
+                "t2", 0,
+                "t3", "MCwwLDAsMCwwLDAsMCwwLDA=",
+                "username", userName,
+                "params", encrypt.getFirst(),
+                "pk", KuGouMusicApiCrypto.cryptoRSAEncrypt(GSON.toJson(Map.of(
+                        "clienttime_ms", dateNow,
+                        "key", encrypt.getSecond()
+                ))).toUpperCase()
+        ));
+
+        JsonObject json = parseJson(
+                request(
+                        "/v9/login_by_pwd",
+                        Map.of(),
+                        KuGouRequestConfig.builder()
+                                .requestType(KuGouRequestConfig.RequestType.POST)
+                                .data(dataMap)
+                                .addHeaders("x-router", "login.user.kugou.com")
+                                .build()
+                )
+        );
+
+        return getLoginData(json, encrypt.getSecond());
+    }
+
+    public Optional<Pair<Long, String>> refreshToken() {
+        String userId = getCookie("userid", "0");
+        String token = getCookie("token", "");
+
+        if (userId.equals("0") || token.isEmpty()) return Optional.empty();
+        long dateNow = System.currentTimeMillis();
+        Pair<String, String> encrypt = KuGouMusicApiCrypto.cryptoAesEncrypt(GSON.toJson(Map.of(
+                "clienttime", Math.floor((double) dateNow / 1000),
+                "token", token
+        )), getKey(), getIv());
+        Pair<String, String> encryptParams = KuGouMusicApiCrypto.cryptoAesEncrypt(GSON.toJson(Map.of()), null, null);
+        String pk = KuGouMusicApiCrypto.cryptoRSAEncrypt(GSON.toJson(Map.of(
+                "clienttime_ms", dateNow,
+                "key", encryptParams.getSecond()
+        )));
+        boolean isLite = ClientConfig.INSTANCE.options.kuGouMusicLite;
+
+        Map<String, Object> dataMap = Map.of(
+                "dfid", getCookie("dfid", "-"),
+                "p3", encrypt.getFirst(),
+                "plat", 1,
+                "t1", 0,
+                "t2", 0,
+                "t3", "MCwwLDAsMCwwLDAsMCwwLDA=",
+                "pk", pk,
+                "params", encryptParams.getFirst(),
+                "userid", userId,
+                "clienttime_ms", dateNow
+        );
+
+        JsonObject json = parseJson(
+                request(
+                        "/" + (isLite ? "v4" : "v5") + "/login_by_token",
+                        Map.of(),
+                        KuGouRequestConfig.builder()
+                                .baseUrl("http://login.user.kugou.com")
+                                .requestType(KuGouRequestConfig.RequestType.POST)
+                                .data(dataMap)
+                                .addHeaders("x-router", "login.user.kugou.com")
+                                .build()
+                )
+        );
+
+        return getLoginData(json, encryptParams.getSecond());
+    }
+
+    public Optional<Pair<Long, String>> getLoginData(JsonObject json, String encryptKey) {
+        Optional<JsonObject> optional = Optional.ofNullable(json);
+
+        Optional<Integer> status = optional.map(object -> object.get("status"))
+                .map(JsonElement::getAsInt);
+
+        if (status.isPresent()) {
+            if (status.get() != 1) return Optional.empty();
+        } else {
+            return Optional.empty();
+        }
+
+        Optional<JsonObject> dataOpt = optional.map(object -> object.getAsJsonObject("data"));
+        try {
+            Long userId = dataOpt.map(data -> data.get("userid"))
+                    .map(JsonElement::getAsLong)
+                    .orElseThrow();
+
+            String token = Optionals
+                    .flatFirstOf(
+                            dataOpt,
+                            data -> Optional
+                                    .ofNullable(data.get("secu_params"))
+                                    .map(JsonElement::getAsString)
+                                    .map(s -> KuGouMusicApiCrypto.cryptoAesDecrypt(s, encryptKey, null)),
+                            data -> Optional.of(data.get("token"))
+                                    .map(JsonElement::getAsString)
+                    )
+                    .orElseThrow();
+
+            try {
+                // 尝试以 json 格式解析
+                JsonObject jsonObject = JsonUtil.from(escapeChars(token));
+                JsonElement element = jsonObject.get("token");
+                if (element != null) {
+                    token = element.getAsString();
+                } else {
+                    return Optional.empty();
+                }
+            } catch (JsonSyntaxException ignored) {
+            }
+
+            return Optional.of(Pair.of(userId, token));
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * 领取酷狗音乐概念版一天畅听 vip, 仅限概念版用户使用
+     * @return 领取结果
+     */
+    public Optional<JsonObject> receiveVip() {
+        // 概念版和普通版都能获取, 但只能在概念版使用, 为避免歧义, 只允许在概念版获取
+        if (!ClientConfig.INSTANCE.options.kuGouMusicLite) return Optional.empty();
+
+        Map<String, String> params = Map.of(
+                "source_id", "90137"
+        );
+        JsonObject json = parseJson(
+                request(
+                        "/youth/v1/recharge/receive_vip_listen_song",
+                        params,
+                        KuGouRequestConfig.builder()
+                                .requestType(KuGouRequestConfig.RequestType.POST)
+                                .build()
+                )
+        );
+
+        return Optional.ofNullable(json);
+    }
+
+    public Optional<JsonObject> lyricSearch(String hash) {
+        if (StringUtils.isEmpty(hash)) return Optional.empty();
+        Map<String, String> paramsMap = Map.of(
+                "album_audio_id", "0",
+                "appid", getUseAppid(),
+                "clientver", getUseClientVer(),
+                "duration", "0",
+                "hash", hash,
+                "keyword", "",
+                "lrctxt", "1",
+                "man", "yes"
+        );
+
+        JsonObject json = parseJson(
+                request(
+                        "/v1/search",
+                        paramsMap,
+                        KuGouRequestConfig.builder()
+                                .baseUrl("https://lyrics.kugou.com")
+                                .clearDefaultParams(true)
+                                .build()
+                )
+        );
+
+        return Optional.ofNullable(json);
+    }
+
+    public Optional<String> getLyric(String id, String accessKey) {
+        Map<String, String> paramsMap = Map.of(
+                "ver", "1",
+                "client", "android",
+                "id", id,
+                "accesskey", accessKey,
+                "fmt", "krc",
+                "charset", "utf8"
+        );
+
+        JsonObject json = parseJson(
+                request(
+                        "/download",
+                        paramsMap,
+                        KuGouRequestConfig.builder()
+                                .baseUrl("https://lyrics.kugou.com")
+                                .build()
+                )
+        );
+
+        return Optional.ofNullable(json)
+                .map(object -> object.get("content"))
+                .map(JsonElement::getAsString);
+    }
+
+    public Optional<JsonObject> getVIPStatus() {
+        Map<String, String> paramsMap = Map.of(
+                "busi_type", "concept",
+                "opt_product_types", "dvip,qvip",
+                "product_type", "svip"
+        );
+
+        JsonObject json = parseJson(
+                request(
+                        "/v1/get_union_vip",
+                        paramsMap,
+                        KuGouRequestConfig.builder()
+                                .baseUrl("https://kugouvip.kugou.com")
+                                .build()
+                )
+        );
+
+        return Optional.ofNullable(json);
+    }
+
+    public String getQRCodeLoginLink(String key) {
+        return "https://h5.kugou.com/apps/loginQRCode/html/index.html?appid=" + getUseAppid() + "&qrcode=" + key;
+    }
+
+    public String getUseAppid() {
+        return ClientConfig.INSTANCE.options.kuGouMusicLite ? LITE_APPID : APPID;
+    }
+
+    public String getUseClientVer() {
+        return ClientConfig.INSTANCE.options.kuGouMusicLite ? LITE_CLIENT_VER : CLIENT_VER;
+    }
+
+    public String getClientTime() {
+        return String.valueOf((long)(Math.floor((double) System.currentTimeMillis() / 1000)));
+    }
+
+    public String getKey() {
+        return ClientConfig.INSTANCE.options.kuGouMusicLite ? LITE_KEY : KEY;
+    }
+
+    public String getIv() {
+        return ClientConfig.INSTANCE.options.kuGouMusicLite ? LITE_IV : IV;
+    }
+
+    public String getCookie(String key) {
+        return COOKIES.getOrDefault(key, "");
+    }
+
+    public String getCookie(String key, String defaultValue) {
+        return COOKIES.getOrDefault(key, "");
+    }
+}

--- a/src/main/java/top/gregtao/concerto/http/kugou/KuGouMusicApiCrypto.java
+++ b/src/main/java/top/gregtao/concerto/http/kugou/KuGouMusicApiCrypto.java
@@ -1,0 +1,198 @@
+package top.gregtao.concerto.http.kugou;
+
+import top.gregtao.concerto.config.ClientConfig;
+import top.gregtao.concerto.util.HashUtil;
+import top.gregtao.concerto.util.Pair;
+import top.gregtao.concerto.util.RandomUtil;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.*;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+import java.util.Map;
+import java.util.zip.Inflater;
+import java.util.zip.InflaterInputStream;
+
+public class KuGouMusicApiCrypto {
+
+    public static final String RSA_PUBKEY = "-----BEGIN PUBLIC KEY-----\nMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDIAG7QOELSYoIJvTFJhMpe1s/gbjDJX51HBNnEl5HXqTW6lQ7LC8jr9fWZTwusknp+sVGzwd40MwP6U5yDE27M/X1+UR4tvOGOqp94TJtQ1EPnWGWXngpeIW5GxoQGao1rmYWAu6oi1z9XkChrsUdC6DJE5E221wf/4WLFxwAtRQIDAQAB\n-----END PUBLIC KEY-----";
+
+    public static final String LITE_RSA_PUBKEY = "-----BEGIN PUBLIC KEY-----\nMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDECi0Np2UR87scwrvTr72L6oO01rBbbBPriSDFPxr3Z5syug0O24QyQO8bg27+0+4kBzTBTBOZ/WWU0WryL1JSXRTXLgFVxtzIY41Pe7lPOgsfTCn5kZcvKhYKJesKnnJDNr5/abvTGf+rHG3YRwsCHcQ08/q6ifSioBszvb3QiwIDAQAB\n-----END PUBLIC KEY-----";
+
+    private static final int[] enKey = {64, 71, 97, 119, 94, 50, 116, 71, 81, 54, 49, 45, 206, 210, 110, 105};
+
+    public static String signAndroidParams(Map<String, String> params, String data) {
+        String paramsString = params.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(entry ->
+                        entry.getKey() + "=" + entry.getValue()
+                )
+                .reduce((a, b) -> a + b)
+                .orElse("");
+        String str = ClientConfig.INSTANCE.options.kuGouMusicLite ? "LnT6xpN3khm36zse0QzvmgTZ3waWdRSA" : "OIlwieks28dk2k092lksi2UIkp";
+        return HashUtil.md5(str + paramsString + data + str).toLowerCase();
+    }
+
+    public static String signWebParams(Map<String, String> params) {
+        String str = "NVPh5oo715z5DIWAeQlhMDsWXXQV4hwt";
+        String paramsString = params.entrySet().stream()
+                .map(entry ->
+                        entry.getKey() + "=" + entry.getValue()
+                )
+                .sorted()
+                .reduce((a, b) -> a + b)
+                .orElse("");
+
+        return HashUtil.md5(str + paramsString + str);
+    }
+
+    public static String signKey(String hash, String mid, String userid, String appid) {
+        String str = ClientConfig.INSTANCE.options.kuGouMusicLite ? "185672dd44712f60bb1736df5a377e82" : "57ae12eb6890223e355ccfcb74edf70d";
+        return HashUtil.md5(hash + str + appid + mid + userid).toLowerCase();
+    }
+
+    public static String signParamsKey(String data) {
+        boolean isLite = ClientConfig.INSTANCE.options.kuGouMusicLite;
+        String str = isLite ? "LnT6xpN3khm36zse0QzvmgTZ3waWdRSA" : "OIlwieks28dk2k092lksi2UIkp";
+        String appid = isLite ? KuGouMusicApiClient.LITE_APPID : KuGouMusicApiClient.APPID;
+        String clientVer = isLite ? KuGouMusicApiClient.LITE_CLIENT_VER : KuGouMusicApiClient.CLIENT_VER;
+
+        return HashUtil.md5(appid + str + clientVer + data).toLowerCase();
+    }
+
+    public static String cryptoRSAEncrypt(String data) {
+        boolean isLite = ClientConfig.INSTANCE.options.kuGouMusicLite;
+        String pubKey = isLite ? LITE_RSA_PUBKEY : RSA_PUBKEY;
+
+        try {
+            byte[] buffer = data.getBytes(StandardCharsets.UTF_8);
+            byte[] padded = new byte[128]; // 1024bit = 128字节
+            System.arraycopy(buffer, 0, padded, 0, buffer.length);
+
+            Cipher cipher = Cipher.getInstance("RSA/ECB/NoPadding");
+            cipher.init(Cipher.ENCRYPT_MODE, loadPublicKey(pubKey));
+            byte[] encrypted = cipher.doFinal(padded);
+
+            return bytesToHex(encrypted).toUpperCase();
+        } catch (GeneralSecurityException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static PublicKey loadPublicKey(String base64Key) throws NoSuchAlgorithmException, InvalidKeySpecException {
+        base64Key = base64Key
+                .replace("-----BEGIN PUBLIC KEY-----", "")
+                .replace("-----END PUBLIC KEY-----", "")
+                .replaceAll("\\s+", "");
+        byte[] keyBytes = Base64.getDecoder().decode(base64Key);
+        return KeyFactory.getInstance("RSA")
+                .generatePublic(new X509EncodedKeySpec(keyBytes));
+    }
+
+    public static Pair<String, String> cryptoAesEncrypt(String data, String keyOpt, String ivOpt) {
+        byte[] buffer = data.getBytes(StandardCharsets.UTF_8);
+
+        String key;
+        String iv;
+        String tempKey = "";
+
+        if (keyOpt != null && ivOpt != null) {
+            key = keyOpt;
+            iv = ivOpt;
+        } else {
+            tempKey = (keyOpt != null) ? keyOpt : RandomUtil.randomString(16).toLowerCase();
+            key = HashUtil.md5(tempKey).substring(0, 32);
+            iv = key.substring(key.length() - 16);
+        }
+
+        try {
+            Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+            SecretKeySpec secretKey = new SecretKeySpec(key.getBytes(StandardCharsets.UTF_8), "AES");
+            IvParameterSpec ivSpec = new IvParameterSpec(iv.getBytes(StandardCharsets.UTF_8));
+            cipher.init(Cipher.ENCRYPT_MODE, secretKey, ivSpec);
+            byte[] encrypted = cipher.doFinal(buffer);
+
+            String hexResult = bytesToHex(encrypted);
+
+            if (keyOpt != null && ivOpt != null) {
+                return new Pair<>(hexResult, null);
+            } else {
+                return new Pair<>(hexResult, tempKey);
+            }
+        } catch (GeneralSecurityException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static String cryptoAesDecrypt(String hexCipherText, String key, String iv) {
+        if (iv == null) {
+            key = HashUtil.md5(key).substring(0, 32);
+        }
+        iv = (iv != null) ? iv : key.substring(key.length() - 16);
+
+        SecretKeySpec secretKey = new SecretKeySpec(key.getBytes(StandardCharsets.UTF_8), "AES");
+        IvParameterSpec ivSpec = new IvParameterSpec(iv.getBytes(StandardCharsets.UTF_8));
+        try {
+            Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+            cipher.init(Cipher.DECRYPT_MODE, secretKey, ivSpec);
+
+            byte[] cipherBytes = hexToBytes(hexCipherText);
+            byte[] plainBytes = cipher.doFinal(cipherBytes);
+
+            return new String(plainBytes, StandardCharsets.UTF_8);
+        } catch (GeneralSecurityException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static byte[] hexToBytes(String hexCipherText) {
+        int len = hexCipherText.length();
+        byte[] data = new byte[len / 2];
+        for (int i = 0; i < len; i += 2) {
+            data[i / 2] = (byte) ((Character.digit(hexCipherText.charAt(i), 16) << 4)
+                    + Character.digit(hexCipherText.charAt(i + 1), 16));
+        }
+        return data;
+    }
+
+    private static String bytesToHex(byte[] bytes) {
+        StringBuilder sb = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) sb.append(String.format("%02x", b & 0xff));
+        return sb.toString();
+    }
+
+    public static String decodeLyrics(String rawLyrics) {
+        try {
+            byte[] bytes = Base64.getDecoder().decode(rawLyrics);
+
+            if (bytes.length <= 4) return "";
+            byte[] krcBytes = new byte[bytes.length - 4];
+            System.arraycopy(bytes, 4, krcBytes, 0, krcBytes.length);
+
+            for (int i = 0; i < krcBytes.length; i++) {
+                krcBytes[i] = (byte) (krcBytes[i] ^ enKey[i % enKey.length]);
+            }
+
+            ByteArrayInputStream bais = new ByteArrayInputStream(krcBytes);
+            InflaterInputStream inflater = new InflaterInputStream(bais, new Inflater());
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+            byte[] buf = new byte[1024];
+            int len;
+            while ((len = inflater.read(buf)) != -1) {
+                baos.write(buf, 0, len);
+            }
+
+            return baos.toString(StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/top/gregtao/concerto/http/kugou/KuGouMusicUser.java
+++ b/src/main/java/top/gregtao/concerto/http/kugou/KuGouMusicUser.java
@@ -1,0 +1,219 @@
+package top.gregtao.concerto.http.kugou;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import top.gregtao.concerto.config.ClientConfig;
+import top.gregtao.concerto.music.list.KuGouMusicPlaylist;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class KuGouMusicUser {
+
+    public static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    private long userId;
+
+    private String userName;
+
+    private String avatarUrl;
+
+    private boolean loggedIn = false;
+
+    private boolean isLite = false;
+
+    private VIPLevel vipLevel = VIPLevel.NONE;
+
+    private LocalDateTime vipExpireTime;
+
+    private final KuGouMusicApiClient apiClient;
+
+    public KuGouMusicUser(KuGouMusicApiClient apiClient) {
+        this.apiClient = apiClient;
+    }
+
+    public long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(long userId) {
+        this.userId = userId;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public String getAvatarUrl() {
+        return avatarUrl;
+    }
+
+    public boolean isLoggedIn() {
+        return loggedIn;
+    }
+
+    public void setLoggedIn(boolean loggedIn) {
+        this.loggedIn = loggedIn;
+    }
+
+    public boolean isLite() {
+        return isLite;
+    }
+
+    public LocalDateTime getVipExpireTime() {
+        return vipExpireTime;
+    }
+
+    public VIPLevel getVipLevel() {
+        return vipLevel;
+    }
+
+    public boolean updateLoginStatus() {
+        Optional<JsonObject> optional = apiClient.getUserDetail();
+
+        try {
+            JsonObject data = optional.map(json -> json.getAsJsonObject("data"))
+                    .orElseThrow();
+
+            Optional<JsonObject> dataOpt = Optional.of(data);
+            this.userName = dataOpt
+                    .map(json -> json.get("nickname"))
+                    .map(JsonElement::getAsString)
+                    .orElseThrow();
+
+            this.avatarUrl = dataOpt
+                    .map(json -> json.get("pic"))
+                    .map(JsonElement::getAsString)
+                    .orElseThrow();
+
+            this.loggedIn = true;
+            this.isLite = ClientConfig.INSTANCE.options.kuGouMusicLite;
+            return true;
+        } catch (Exception e) {
+            this.loggedIn = false;
+            return false;
+        }
+    }
+
+    public boolean updateVIPStatus() {
+        if (!this.loggedIn) return false;
+        Optional<JsonObject> optional = KuGouMusicApiClient.INSTANCE.getVIPStatus();
+        if (optional.map(json -> json.get("status")).isEmpty()) {
+            this.vipLevel = VIPLevel.NONE;
+            this.vipExpireTime = null;
+            return false;
+        }
+
+        Optional<JsonObject> dataOpt = optional.map(json -> json.getAsJsonObject("data"));
+
+        LocalDateTime maxExpireTime = LocalDateTime.now();
+        VIPLevel maxExpireLevel = VIPLevel.NONE;
+
+
+        String vipEndTime = dataOpt.map(json -> json.get("vip_end_time"))
+                .map(JsonElement::getAsString)
+                .orElse("");
+
+        if (!vipEndTime.isEmpty()) {
+            LocalDateTime expireTime = parseTime(vipEndTime);
+            if (expireTime.isAfter(maxExpireTime)) {
+                maxExpireLevel = VIPLevel.VIP;
+                maxExpireTime = expireTime;
+            }
+        }
+
+        String suVIPEndTime = dataOpt.map(json -> json.get("su_vip_end_time"))
+                .map(JsonElement::getAsString)
+                .orElse("");
+
+        if (!suVIPEndTime.isEmpty()) {
+            LocalDateTime expireTime = parseTime(suVIPEndTime);
+            if (expireTime.isAfter(maxExpireTime)) {
+                maxExpireLevel = VIPLevel.S_VIP;
+                maxExpireTime = expireTime;
+            }
+        }
+
+        // 如果是概念版, 检查概念版的 VIP
+        if (isLite()) {
+            Optional<JsonArray> busiVipArray = dataOpt.map(json -> json.getAsJsonArray("busi_vip"));
+            if (busiVipArray.isPresent()) {
+                for (JsonElement element : busiVipArray.get()) {
+                    try {
+                        Optional<JsonObject> objectOpt = Optional.ofNullable(element.getAsJsonObject());
+                        String productType = objectOpt.map(obj -> obj.get("product_type"))
+                                .map(JsonElement::getAsString)
+                                .orElseThrow();
+
+                        String expireTime = objectOpt.map(obj -> obj.get("vip_end_time"))
+                                .map(JsonElement::getAsString)
+                                .orElseThrow();
+
+                        LocalDateTime time = parseTime(expireTime);
+                        if (time.isAfter(maxExpireTime)) {
+                            if (productType.equals("svip")) {
+                                maxExpireLevel = VIPLevel.BUSI_S_VIP;
+                            } else if (productType.equals("tvip")) {
+                                maxExpireLevel = VIPLevel.BUSI_T_VIP;
+                            } else {
+                                continue;
+                            }
+                            maxExpireTime = time;
+                        }
+                    } catch (Exception ignore) {
+                    }
+                }
+            }
+        }
+
+        this.vipLevel = maxExpireLevel;
+        this.vipExpireTime = maxExpireLevel != VIPLevel.NONE ? maxExpireTime : null;
+        return true;
+    }
+
+    private LocalDateTime parseTime(String time) {
+        return LocalDateTime.from(FORMATTER.parse(time));
+    }
+
+    public void logout() {
+        this.apiClient.clearCookie();
+        this.loggedIn = false;
+    }
+
+    public List<KuGouMusicPlaylist> getUserPlaylists(int page) {
+        if (!this.loggedIn) return new ArrayList<>();
+        Optional<JsonObject> optional = apiClient.getUserPlaylists(page);
+
+        return optional.map(json -> json.getAsJsonObject("data"))
+                .map(data -> data.getAsJsonArray("info"))
+                .map(info -> info.asList().stream()
+                        .map(element -> new KuGouMusicPlaylist(element.getAsJsonObject(), false, true))
+                        .collect(Collectors.toList())
+                )
+                .orElse(new ArrayList<>());
+    }
+
+    /**
+     * 判断用户接口版本和配置版本是否相同
+     */
+    public boolean isVersionSame() {
+        return this.isLite == ClientConfig.INSTANCE.options.kuGouMusicLite;
+    }
+
+    public enum VIPLevel {
+        NONE,
+        // 豪华 VIP
+        VIP,
+        // 超级 VIP
+        S_VIP,
+        // 概念版 VIP (仅概念版)
+        BUSI_S_VIP,
+        // 畅听 VIP (仅概念版)
+        BUSI_T_VIP
+    }
+}

--- a/src/main/java/top/gregtao/concerto/http/kugou/KuGouRequestConfig.java
+++ b/src/main/java/top/gregtao/concerto/http/kugou/KuGouRequestConfig.java
@@ -1,0 +1,134 @@
+package top.gregtao.concerto.http.kugou;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class KuGouRequestConfig {
+
+    private final boolean needKey;
+
+    private final boolean noSign;
+
+    private final String baseUrl;
+
+    private final RequestType requestType;
+
+    private final Map<String, String> headers;
+
+    private final Object data;
+
+    private final EncryptType encryptType;
+
+    private final boolean clearDefaultParams;
+
+    public KuGouRequestConfig(boolean needKey, boolean noSign, String baseUrl, RequestType requestType, Map<String, String> headers, Object data, EncryptType encryptType, boolean clearDefaultParams) {
+        this.needKey = needKey;
+        this.noSign = noSign;
+        this.baseUrl = baseUrl;
+        this.requestType = requestType;
+        this.headers = headers;
+        this.data = data;
+        this.encryptType = encryptType;
+        this.clearDefaultParams = clearDefaultParams;
+    }
+
+    public boolean isNeedKey() {
+        return needKey;
+    }
+
+    public boolean isNoSign() {
+        return noSign;
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public RequestType getRequestType() {
+        return requestType;
+    }
+
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+
+    public Object getData() {
+        return data;
+    }
+
+    public EncryptType getEncryptType() {
+        return encryptType;
+    }
+
+    public boolean isClearDefaultParams() {
+        return clearDefaultParams;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private boolean needKey = false;
+        private boolean noSign = false;
+        private String baseUrl = null;
+        private RequestType requestType = RequestType.GET;
+        private Map<String, String> headers = new HashMap<>();
+        private Object data = null;
+        private EncryptType encryptType = EncryptType.ANDROID;
+        private boolean clearDefaultParams = false;
+
+        public Builder needKey(boolean needKey) {
+            this.needKey = needKey;
+            return this;
+        }
+
+        public Builder noSign(boolean noSign) {
+            this.noSign = noSign;
+            return this;
+        }
+
+        public Builder baseUrl(String baseUrl) {
+            this.baseUrl = baseUrl;
+            return this;
+        }
+
+        public Builder requestType(RequestType requestType) {
+            this.requestType = requestType;
+            return this;
+        }
+
+        public Builder addHeaders(String key, String value) {
+            this.headers.put(key, value);
+            return this;
+        }
+
+        public Builder data(Object data) {
+            this.data = data;
+            return this;
+        }
+
+        public Builder encryptType(EncryptType encryptType) {
+            this.encryptType = encryptType;
+            return this;
+        }
+        public Builder clearDefaultParams(boolean clearDefaultParams) {
+            this.clearDefaultParams = clearDefaultParams;
+            return this;
+        }
+
+        public KuGouRequestConfig build() {
+            return new KuGouRequestConfig(needKey, noSign, baseUrl, requestType, headers, data, encryptType, clearDefaultParams);
+        }
+    }
+
+    public enum RequestType {
+        GET,
+        POST
+    }
+
+    public enum EncryptType {
+        WEB,
+        ANDROID
+    }
+}

--- a/src/main/java/top/gregtao/concerto/music/KuGouMusic.java
+++ b/src/main/java/top/gregtao/concerto/music/KuGouMusic.java
@@ -1,0 +1,445 @@
+package top.gregtao.concerto.music;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import top.gregtao.concerto.api.*;
+import top.gregtao.concerto.enums.Sources;
+import top.gregtao.concerto.http.HttpURLInputStream;
+import top.gregtao.concerto.http.kugou.KuGouMusicApiClient;
+import top.gregtao.concerto.http.kugou.KuGouMusicApiCrypto;
+import top.gregtao.concerto.music.lyrics.DefaultFormatLyrics;
+import top.gregtao.concerto.music.lyrics.Lyrics;
+import top.gregtao.concerto.music.meta.music.BasicMusicMetaData;
+import top.gregtao.concerto.music.meta.music.MusicMetaData;
+import top.gregtao.concerto.music.meta.music.UnknownMusicMeta;
+import top.gregtao.concerto.util.FileUtil;
+import top.gregtao.concerto.util.LyricsUtil;
+import top.gregtao.concerto.util.Optionals;
+import top.gregtao.concerto.util.Pair;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class KuGouMusic extends Music implements CacheableMusic, DynamicPath {
+
+    private final String albumAudioId;
+
+    private String hash;
+
+    private String rawPath, rawLyrics, rawSubLyrics, format;
+
+    private Map<Level, String> hashMap = new HashMap<>();
+
+    public KuGouMusic(String id, String hash, boolean isEncodeAlbumAudioId) {
+        this.albumAudioId = isEncodeAlbumAudioId ? toAlbumAudioId(id) : id;
+        this.hash = hash;
+    }
+
+    public KuGouMusic(String id, boolean isEncodeAlbumAudioId) {
+        this(id, "", isEncodeAlbumAudioId);
+    }
+
+    /**
+     * 构造函数, 通过 JsonObject 初始化 KuGouMusic 对象
+     * <p>
+     * 只接受 searchMusic 和 getPlayListAllTrack 返回的 Json 对象
+     * @param object Json 对象, 来自搜索或歌单等接口
+     */
+    public KuGouMusic(JsonObject object) {
+        Optional<JsonObject> optional = Optional.ofNullable(object);
+
+        this.albumAudioId = Optionals
+                .firstOf(
+                        optional,
+                        json -> json.get("MixSongID"),
+                        json -> json.get("mixsongid")
+                )
+                .map(JsonElement::getAsString)
+                .orElse("");
+
+        this.hash = Optionals
+                .firstOf(
+                        optional,
+                        json -> json.get("FileHash"),
+                        json -> json.get("hash")
+                )
+                .map(JsonElement::getAsString)
+                .orElse("");
+
+        this.setMusicMeta(parseMetaDataForSong(object));
+    }
+
+    public KuGouMusic(MusicMetaData metaData, String albumAudioId, String hash) {
+        this.setMusicMeta(metaData);
+        this.albumAudioId = albumAudioId;
+        this.hash = hash;
+    }
+
+    public String getAlbumAudioId() {
+        return albumAudioId;
+    }
+
+    public String getHash() {
+        return hash;
+    }
+
+    public Map<Level, String> getHashMap() {
+        if (hashMap.isEmpty()) return updateHashMap();
+        return hashMap;
+    }
+
+    public Map<Level, String> updateHashMap() {
+        Optional<JsonObject> optional = KuGouMusicApiClient.INSTANCE.getMusicHash(this.hash);
+        optional.map(json -> json.getAsJsonArray("data"))
+                .map(dataArray -> !dataArray.isEmpty() ? dataArray.get(0).getAsJsonObject() : null)
+                .ifPresent(data -> {
+                    for (Level level : Level.values()) {
+                        JsonElement jsonElement = data.get(level.getKey());
+                        // 有些音质的音乐可能没有
+                        if (jsonElement != null && !jsonElement.getAsString().isEmpty()) {
+                            hashMap.put(level, jsonElement.getAsString());
+                        }
+                    }
+                });
+        return hashMap;
+    }
+
+    @Override
+    public String getSuffix() {
+        return this.getLastSuffix();
+    }
+
+    @Override
+    public Music getMusic() {
+        return this;
+    }
+
+    @Override
+    public String getLastRawPath() {
+        if (this.rawPath == null) this.getRawPath();
+        return this.rawPath;
+    }
+
+    @Override
+    public String updateRawPath() {
+        return this.getRawPath();
+    }
+
+    @Override
+    public String getLastSuffix() {
+        if (this.format == null) this.getRawPath();
+        return this.format;
+    }
+
+    @Override
+    public String getLastLyrics() {
+        if (this.rawLyrics == null) this.getLyrics();
+        return this.rawLyrics;
+    }
+
+    @Override
+    public Pair<Lyrics, Lyrics> getLyrics() {
+        try {
+            Optional<JsonObject> optional = KuGouMusicApiClient.INSTANCE.lyricSearch(this.hash);
+            JsonArray jsonArray = optional.map(obj -> obj.getAsJsonArray("candidates"))
+                    .orElse(new JsonArray());
+            Pair<String, String> bestLyric = getBestLyric(jsonArray);
+
+            Pair<String, String> pair = KuGouMusicApiClient.INSTANCE.getLyric(bestLyric.getFirst(), bestLyric.getSecond())
+                    .map(KuGouMusicApiCrypto::decodeLyrics)
+                    .map(LyricsUtil::krcToLrc)
+                    .orElseThrow();
+
+            this.rawLyrics = pair.getFirst();
+            this.rawSubLyrics = pair.getSecond();
+
+            return Pair.of(
+                    new DefaultFormatLyrics().load(pair.getFirst()),
+                    new DefaultFormatLyrics().load(pair.getSecond())
+            );
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public Pair<String, String> getBestLyric(JsonArray jsonArray) {
+        if (jsonArray.isEmpty()) return null;
+        List<JsonElement> list = jsonArray.asList();
+        for (JsonElement jsonElement : list) {
+            Optional<JsonObject> object = Optional.of(jsonElement.getAsJsonObject());
+            Optional<Integer> contentFormat = object.map(obj -> obj.get("content_format"))
+                    .map(JsonElement::getAsInt);
+
+            if (contentFormat.isPresent() && contentFormat.get() > 1) {
+                String id = object.map(obj -> obj.get("id"))
+                        .map(JsonElement::getAsString)
+                        .orElseThrow();
+
+                String accessKey = object.map(obj -> obj.get("accesskey"))
+                        .map(JsonElement::getAsString)
+                        .orElseThrow();
+
+                return Pair.of(id, accessKey);
+            }
+        }
+
+        Optional<JsonObject> object = Optional.ofNullable(list.getFirst().getAsJsonObject());
+        String id = object.map(obj -> obj.get("id"))
+                .map(JsonElement::getAsString)
+                .orElseThrow();
+
+        String accessKey = object.map(obj -> obj.get("accesskey"))
+                .map(JsonElement::getAsString)
+                .orElseThrow();
+
+        return Pair.of(id, accessKey);
+    }
+
+    @Override
+    public String getLastSubLyrics() {
+        return this.rawSubLyrics;
+    }
+
+    @Override
+    public JsonParser<Music> getJsonParser() {
+        return MusicJsonParsers.KUGOU_MUSIC;
+    }
+
+    @Override
+    public InputStream getMusicSource() throws MusicSourceNotFoundException {
+        try {
+            return FileUtil.createBuffered(new HttpURLInputStream(URI.create(this.getRawPath()).toURL(), this::getRawPath));
+        } catch (Exception e) {
+            throw new MusicSourceNotFoundException(e);
+        }
+    }
+
+    @Override
+    public String getLink() {
+        // album_audio_id 暂时无法转换为 encode_album_audio_id, 无法生成链接
+        return "https://www.kugou.com/";
+    }
+
+    @Override
+    public void load() {
+        Optional<JsonObject> musicDetail = KuGouMusicApiClient.INSTANCE.getMusicDetail(albumAudioId, "album_info,base,authors.base,audio_info");
+
+        try {
+            musicDetail.map(json -> json.getAsJsonObject("audio_info"))
+                    .map(audioInfo -> audioInfo.get("hash"))
+                    .map(JsonElement::getAsString)
+                    .ifPresent(hash -> this.hash = hash);
+        } catch (Exception ignore) {
+        }
+
+        this.setMusicMeta(
+                musicDetail
+                        .map(KuGouMusic::parseMetaData)
+                        .orElseGet(() -> new UnknownMusicMeta(Sources.KUGOU_MUSIC.getName().getString()))
+        );
+        super.load();
+    }
+
+    /**
+     * 解析音乐元数据, 处理 getDetail 和 getAlbumSongs 返回的 Json 对象
+     * @param object 音乐详情 Json 对象
+     * @return 音乐元数据
+     */
+    public static MusicMetaData parseMetaData(JsonObject object) {
+
+        Optional<JsonObject> optional = Optional.of(object);
+
+        try {
+            String name = Optionals
+                    .firstOf(
+                            optional.map(json -> json.getAsJsonObject("base")),
+                            // getDetail 接口
+                            json -> json.get("songname"),
+                            // getAlbumSongs 接口
+                            json -> json.get("audio_name")
+                    )
+                    .map(JsonElement::getAsString)
+                    .orElseThrow();
+
+            Long duration = Optionals
+                    .firstOf(
+                            optional.map(json -> json.getAsJsonObject("audio_info")),
+                            // getDetail 接口
+                            json -> json.get("timelength"),
+                            // getAlbumSongs 接口
+                            json -> json.get("duration")
+                    )
+                    .map(JsonElement::getAsLong)
+                    .orElseThrow();
+
+            List<String> authorList = optional.map(json -> json.getAsJsonArray("authors"))
+                    .map(arr -> arr.asList().stream()
+                            .map(JsonElement::getAsJsonObject)
+                            .map(Optional::of)
+                            .map(authorOpt -> Optionals
+                                    .flatFirstOf(
+                                        authorOpt,
+                                        // getDetail 接口会再套一层 base 对象
+                                        json -> Optional.ofNullable(json.getAsJsonObject("base")),
+                                        Optional::ofNullable
+                                    )
+                                    // 获取到 author_name 所在对象
+                                    .map(base -> base.get("author_name"))
+                            )
+                            .filter(nameElementOpt -> nameElementOpt.isPresent() && !nameElementOpt.get().isJsonNull())
+                            .map(nameElementOpt -> nameElementOpt.get().getAsString())
+                            .collect(Collectors.toList())
+                    )
+                    .orElseThrow();
+
+            String headPic = optional.map(json -> json.getAsJsonObject("album_info"))
+                    .map(albumInfo -> albumInfo.get("cover"))
+                    .map(coverElement -> {
+                        if (coverElement.isJsonNull()) return "";
+                        String cover = coverElement.getAsString();
+                        return cover.replace("{size}", "512");
+                    })
+                    .orElseThrow();
+            return new BasicMusicMetaData(String.join(", ", authorList), name,
+                    Sources.KUGOU_MUSIC.getName().getString(), duration, headPic);
+        } catch (Exception e) {
+            return new UnknownMusicMeta(Sources.KUGOU_MUSIC.getName().getString());
+        }
+    }
+
+    /**
+     * 解析音乐元数据, 处理 searchMusic 和 getPlayListAllTrack 返回的 Json 对象
+     * @param object 音乐详情 Json 对象
+     * @return 音乐元数据
+     */
+    public static MusicMetaData parseMetaDataForSong(JsonObject object) {
+        Optional<JsonObject> optional = Optional.ofNullable(object);
+
+        try {
+            // 两个接口的 Json 字段名不相同, 需要分别处理
+            long duration = Optionals
+                    .flatFirstOf(
+                            optional,
+                            // searchMusic 接口
+                            json -> Optional.ofNullable(json.get("Duration"))
+                                    .map(JsonElement::getAsLong)
+                                    .map(l -> l * 1000),
+                            // getPlaylist 接口
+                            json -> Optional.ofNullable(json.get("timelen"))
+                                    .map(JsonElement::getAsLong)
+                    ).orElseThrow();
+
+            List<String> authorsList = Optionals
+                    .firstOf(
+                            optional,
+                            // searchMusic 接口
+                            json -> json.get("Singers"),
+                            // getPlaylist 接口
+                            json -> json.get("singerinfo")
+                    )
+                    .map(JsonElement::getAsJsonArray)
+                    .map(arr ->
+                            // 提取歌手名称
+                            arr.asList().stream()
+                                    .map(JsonElement::getAsJsonObject)
+                                    .map(json -> json.get("name"))
+                                    .filter(Objects::nonNull)
+                                    .map(JsonElement::getAsString)
+                                    .collect(Collectors.toList())
+                    ).orElseThrow();
+
+            String headPic = Optionals
+                    .firstOf(
+                            optional,
+                            // searchMusic 接口
+                            json -> json.get("Image"),
+                            // getPlaylist 接口
+                            json -> json.get("cover")
+                    )
+                    .map(JsonElement::getAsString)
+                    .map(pic -> pic.replace("{size}", "512"))
+                    .orElseThrow();
+
+            String title = Optionals
+                    .firstOf(
+                            optional,
+                            // searchMusic 接口
+                            json -> json.get("FileName"),
+                            // getPlaylist 接口
+                            json -> json.get("name")
+                    )
+                    .map(JsonElement::getAsString)
+                    .map(fullName -> {
+                        // 名称格式为 "歌手一、歌手二 - 歌曲"
+                        // 注意分隔符为中文顿号
+                        return fullName.replace(String.join("、", authorsList) + " - ", "");
+                    })
+                    .orElseThrow();
+
+            return new BasicMusicMetaData(String.join(", ", authorsList), title,
+                    Sources.KUGOU_MUSIC.getName().getString(), duration, headPic);
+        } catch (Exception e) {
+            return new UnknownMusicMeta(Sources.KUGOU_MUSIC.getName().getString());
+        }
+    }
+
+
+    public String getRawPath() {
+        String topHash = getTopHash();
+        Optional<String> topMusicLink = KuGouMusicApiClient.INSTANCE.getMusicLink(topHash, true);
+        if (topMusicLink.isPresent()) {
+            this.rawPath = topMusicLink.get();
+            this.format = FileUtil.getSuffix(URI.create(this.rawPath).getPath());
+        } else {
+            this.rawPath = null;
+            this.format = null;
+        }
+        return this.rawPath;
+    }
+
+    public String toAlbumAudioId(String encodeAlbumAudioId) {
+        if (encodeAlbumAudioId == null || encodeAlbumAudioId.length() < 3) throw new IllegalArgumentException("Invalid encodeAlbumAudioId");
+        // 先去除后两位
+        encodeAlbumAudioId = encodeAlbumAudioId.substring(0, encodeAlbumAudioId.length() - 2);
+        // 再将剩下的部分从36进制转换为10进制
+        long num = Long.parseLong(encodeAlbumAudioId, 36);
+        return String.valueOf(num);
+    }
+
+    /**
+     * 获取最高音质的 Hash
+     * @return Hash
+     */
+    public String getTopHash() {
+        return this.getHashMap().entrySet().stream()
+                .min(Map.Entry.comparingByKey((a, b) -> Integer.compare(b.getRank(), a.getRank())))
+                .orElseGet(() -> Map.entry(Level.STANDARD, this.hash))
+                .getValue();
+    }
+
+    public enum Level {
+        STANDARD(0, "hash_128"),
+        HIGH(1, "hash_320"),
+        LOSSLESS(2, "hash_flac"),
+        HIRES(3, "hash_high");
+
+        private final int rank;
+        private final String key;
+
+        Level(int rank, String key) {
+            this.rank = rank;
+            this.key = key;
+        }
+
+        public int getRank() {
+            return rank;
+        }
+
+        public String getKey() {
+            return key;
+        }
+    }
+}

--- a/src/main/java/top/gregtao/concerto/music/list/KuGouMusicPlaylist.java
+++ b/src/main/java/top/gregtao/concerto/music/list/KuGouMusicPlaylist.java
@@ -1,0 +1,158 @@
+package top.gregtao.concerto.music.list;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import top.gregtao.concerto.http.kugou.KuGouMusicApiClient;
+import top.gregtao.concerto.music.Music;
+import top.gregtao.concerto.music.meta.music.list.PlaylistMetaData;
+import top.gregtao.concerto.util.MathUtil;
+import top.gregtao.concerto.util.Optionals;
+import top.gregtao.concerto.util.Pair;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class KuGouMusicPlaylist extends Playlist {
+
+    private final String id;
+
+    public KuGouMusicPlaylist(String id, boolean isAlbum) {
+        super(isAlbum);
+        this.id = id;
+    }
+
+    public KuGouMusicPlaylist(JsonObject object, boolean isAlbum, boolean isFromDetail) {
+        super(isAlbum);
+
+        if (!isAlbum) {
+            this.id = Optional.ofNullable(object)
+                    .map(json -> json.get(isFromDetail ? "global_collection_id" : "gid"))
+                    .map(JsonElement::getAsString)
+                    .orElseThrow();
+            this.meta = parsePlaylistInfo(object, isFromDetail);
+        } else {
+            this.id = Optional.ofNullable(object)
+                    .map(json -> json.get("albumid"))
+                    .map(JsonElement::getAsString)
+                    .orElseThrow();
+            this.meta = parseAlbumInfo(object);
+        }
+
+        this.loaded = true;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public static PlaylistMetaData parsePlaylistInfo(JsonObject jsonObject, boolean isDetail) {
+        String authorKey = isDetail ? "list_create_username" : "nickname" ;
+        String titleKey = isDetail ? "name" : "specialname";
+
+        Optional<JsonObject> optional = Optional.ofNullable(jsonObject);
+        String author = optional.map(json -> json.get(authorKey))
+                .map(JsonElement::getAsString)
+                .orElse("");
+
+        String title = optional.map(json -> json.get(titleKey))
+                .map(JsonElement::getAsString)
+                .orElse("");
+
+        String desc = optional.map(json -> json.get("intro"))
+                .map(JsonElement::getAsString)
+                .orElse("");
+
+        String createTime = optional.map(json -> json.get("create_time"))
+                .map(JsonElement::getAsString)
+                .map(Integer::parseInt)
+                .map(i -> i * 1000L)
+                .map(MathUtil::formattedTime)
+                .orElse("");
+
+        return new PlaylistMetaData(author, title, createTime, desc);
+    }
+
+    /**
+     * 解析专辑元数据, 处理 searchAlbum 和 getAlbumDetail 返回的数据
+     * @param jsonObject 专辑的 JsonObject
+     * @return 专辑元数据
+     */
+    public static PlaylistMetaData parseAlbumInfo(JsonObject jsonObject) {
+        Optional<JsonObject> optional = Optional.ofNullable(jsonObject);
+
+        String title = Optionals
+                .firstOf(
+                        optional,
+                        // searchAlbum 接口返回的专辑数据
+                        json -> json.get("albumname"),
+                        // getAlbumDetail 接口返回的专辑数据
+                        json -> json.get("album_name")
+                )
+                .map(JsonElement::getAsString)
+                .orElse("");
+
+        List<String> authorsList = Optionals
+                .firstOf(
+                        optional,
+                        // searchAlbum 接口
+                        json -> json.getAsJsonArray("singers"),
+                        // getAlbumDetail 接口
+                        json -> json.getAsJsonArray("authors")
+                )
+                .map(arr -> arr.asList().stream())
+                // 作者/歌手列表中字段不一样, 需要分别处理
+                .map(stream -> stream
+                        .map(JsonElement::getAsJsonObject)
+                        .map(object -> Optionals
+                                .firstOf(
+                                        Optional.of(object),
+                                        // searchAlbum 接口
+                                        json -> json.get("name"),
+                                        // getAlbumDetail 接口
+                                        json -> json.get("author_name")
+                                )
+                                .map(JsonElement::getAsString)
+                                .orElse("")
+                        ).collect(Collectors.toList())
+                )
+                .orElse(new ArrayList<>());
+
+        String desc = optional.map(json -> json.get("intro"))
+                .map(JsonElement::getAsString)
+                .orElse("");
+
+        String createTime = Optionals
+                .firstOf(
+                        optional,
+                        json -> json.get("publish_time"),
+                        json -> json.get("publish_date")
+                )
+                .map(JsonElement::getAsString)
+                .orElse("");
+
+        return new PlaylistMetaData(
+                String.join(", ", authorsList),
+                title,
+                createTime,
+                desc
+        );
+    }
+
+    @Override
+    Pair<ArrayList<Music>, PlaylistMetaData> loadData() {
+        return isAlbum ?
+                KuGouMusicApiClient.INSTANCE.getAlbum(this.id) :
+                KuGouMusicApiClient.INSTANCE.getPlaylist(this.id);
+    }
+
+    @Override
+    public ArrayList<Music> getList() {
+        Pair<ArrayList<Music>, PlaylistMetaData> pair = this.loadData();
+        this.list = pair.getFirst();
+        this.meta = pair.getSecond();
+        this.loaded = true;
+        return this.list;
+    }
+}

--- a/src/main/java/top/gregtao/concerto/music/parser/KuGouMusicJsonParser.java
+++ b/src/main/java/top/gregtao/concerto/music/parser/KuGouMusicJsonParser.java
@@ -1,0 +1,26 @@
+package top.gregtao.concerto.music.parser;
+
+import com.google.gson.JsonObject;
+import top.gregtao.concerto.api.JsonParser;
+import top.gregtao.concerto.enums.Sources;
+import top.gregtao.concerto.music.KuGouMusic;
+
+public class KuGouMusicJsonParser implements JsonParser<KuGouMusic> {
+    @Override
+    public KuGouMusic fromJson(JsonObject object) {
+        return new KuGouMusic(object.get("id").getAsString(),
+                object.get("hash").getAsString(), false);
+    }
+
+    @Override
+    public JsonObject toJson(JsonObject object, KuGouMusic kuGouMusic) {
+        object.addProperty("id", kuGouMusic.getAlbumAudioId());
+        object.addProperty("hash", kuGouMusic.getHash());
+        return object;
+    }
+
+    @Override
+    public String name() {
+        return Sources.KUGOU_MUSIC.asString();
+    }
+}

--- a/src/main/java/top/gregtao/concerto/network/MusicDataPacket.java
+++ b/src/main/java/top/gregtao/concerto/network/MusicDataPacket.java
@@ -15,7 +15,8 @@ public class MusicDataPacket {
 
     public static List<String> ALLOWED_SOURCES = List.of(
             Sources.NETEASE_CLOUD.asString(),
-            Sources.QQ_MUSIC.asString()
+            Sources.QQ_MUSIC.asString(),
+            Sources.KUGOU_MUSIC.asString()
     );
 
     public static boolean isMusicSafe(Music music) {

--- a/src/main/java/top/gregtao/concerto/screen/AddMusicScreen.java
+++ b/src/main/java/top/gregtao/concerto/screen/AddMusicScreen.java
@@ -67,6 +67,11 @@ public class AddMusicScreen extends ApplyDraggedFileScreen {
                 str -> MusicPlayer.INSTANCE.addMusicHere(new QQMusic(str), true, () -> {
                     if (!MusicPlayer.INSTANCE.started) MusicPlayer.INSTANCE.start();
                 }));
+
+        this.addLabel(
+                Text.translatable("concerto.screen.add.kugou"), this.width / 2, 195,
+                str -> MusicPlayer.INSTANCE.addMusicHere(new KuGouMusic(str, true), true)
+        );
 //        this.addLabel(Text.translatable("concerto.screen.add.bilibili"), this.width / 2, 195,
 //                str -> MusicPlayer.INSTANCE.addMusicHere(new BilibiliMusic(str), true));
     }

--- a/src/main/java/top/gregtao/concerto/screen/ConcertoIndexScreen.java
+++ b/src/main/java/top/gregtao/concerto/screen/ConcertoIndexScreen.java
@@ -12,6 +12,7 @@ import net.minecraft.util.Util;
 import top.gregtao.concerto.ConcertoClient;
 import top.gregtao.concerto.config.PresetPlaylistsConfig;
 import top.gregtao.concerto.network.room.MusicRoom;
+import top.gregtao.concerto.screen.kugou.KuGouMusicIndexScreen;
 import top.gregtao.concerto.screen.qq.QQMusicIndexScreen;
 import top.gregtao.concerto.screen.netease.NeteaseCloudIndexScreen;
 
@@ -48,6 +49,10 @@ public class ConcertoIndexScreen extends ConcertoScreen {
                 button -> MinecraftClient.getInstance().setScreen(new QQMusicIndexScreen(this))
         ).position(this.width / 2 - 120, 80).size(115, 20).build());
 
+        this.addDrawableChild(ButtonWidget.builder(Text.translatable("concerto.screen.index.kugou"),
+                button -> MinecraftClient.getInstance().setScreen(new KuGouMusicIndexScreen(this))
+        ).position(this.width / 2 - 120, 110).size(115, 20).build());
+
         ButtonWidget widget1 = ButtonWidget.builder(Text.translatable("concerto.screen.preset_radios"),
                 button -> MinecraftClient.getInstance().setScreen(new PresetRadiosScreen(this))
         ).position(this.width / 2 + 5, 80).size(115, 20).build();
@@ -58,7 +63,7 @@ public class ConcertoIndexScreen extends ConcertoScreen {
 
         this.addDrawableChild(ButtonWidget.builder(Text.translatable("concerto.screen.add"),
                 button -> MinecraftClient.getInstance().setScreen(new AddMusicScreen(this)))
-            .position(this.width / 2 - 120, 110).size(115, 20).build());
+            .position(this.width / 2 - 120, 140).size(115, 20).build());
 
         this.addDrawableChild(ButtonWidget.builder(Text.translatable("concerto.screen.local_playlists"),
             button -> MinecraftClient.getInstance().setScreen(new PlaylistListScreen(
@@ -71,7 +76,7 @@ public class ConcertoIndexScreen extends ConcertoScreen {
 
         this.addDrawableChild(ButtonWidget.builder(Text.translatable("concerto.screen.options"),
                 button -> MinecraftClient.getInstance().setScreen(new ConcertoOptionsScreen(this))
-        ).position(this.width / 2 - 120, 140).size(115, 20).build());
+        ).position(this.width / 2 - 120, 170).size(115, 20).build());
 
         if (this.client != null) {
             switch (ConcertoClient.clientState) {
@@ -80,7 +85,7 @@ public class ConcertoIndexScreen extends ConcertoScreen {
                     Text text = Text.translatable("concerto.screen.in_music_room", uuid);
                     int width = this.textRenderer.getWidth(text);
                     this.addDrawableChild(new PressableTextWidget(
-                        (this.width - width) / 2, 185, width,
+                        (this.width - width) / 2, 215, width,
                         this.textRenderer.fontHeight, text,
                         button -> this.client.keyboard.setClipboard(uuid),
                         this.textRenderer
@@ -90,7 +95,7 @@ public class ConcertoIndexScreen extends ConcertoScreen {
                     Text text = Text.translatable("concerto.screen.in_music_agent");
                     int width = this.textRenderer.getWidth(text);
                     this.addDrawableChild(new TextWidget(
-                        (this.width - width) / 2, 185, width,
+                        (this.width - width) / 2, 215, width,
                         this.textRenderer.fontHeight, text,
                         this.textRenderer
                     ));
@@ -106,7 +111,7 @@ public class ConcertoIndexScreen extends ConcertoScreen {
             matrices.drawCenteredTextWithShadow(
                 this.textRenderer,
                 Text.translatable("concerto.screen.in_which_room"),
-                this.width / 2, 170, 0xffffffff
+                this.width / 2, 200, 0xffffffff
             );
         }
     }

--- a/src/main/java/top/gregtao/concerto/screen/ConcertoScreen.java
+++ b/src/main/java/top/gregtao/concerto/screen/ConcertoScreen.java
@@ -5,6 +5,7 @@ import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.widget.NarratedMultilineTextWidget;
 import net.minecraft.client.gui.widget.PressableTextWidget;
+import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.text.Style;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
@@ -75,6 +76,11 @@ public class ConcertoScreen extends Screen {
         this.renderBackground(matrices, mouseX, mouseY, delta);
         super.render(matrices, mouseX, mouseY, delta);
         matrices.drawCenteredTextWithShadow(this.textRenderer, this.title, this.width / 2, 5, 0xffffffff);
+        // 修复 message 背景被遮挡的问题
+        MatrixStack matrixStack = matrices.getMatrices();
+        matrixStack.push();
+        matrixStack.translate(0, 0, 200);
         this.message.render(matrices, mouseX, mouseY, delta);
+        matrixStack.pop();
     }
 }

--- a/src/main/java/top/gregtao/concerto/screen/kugou/KuGouMusicIndexScreen.java
+++ b/src/main/java/top/gregtao/concerto/screen/kugou/KuGouMusicIndexScreen.java
@@ -1,0 +1,138 @@
+package top.gregtao.concerto.screen.kugou;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.text.Text;
+import top.gregtao.concerto.config.ClientConfig;
+import top.gregtao.concerto.http.kugou.KuGouMusicApiClient;
+import top.gregtao.concerto.http.kugou.KuGouMusicUser;
+import top.gregtao.concerto.screen.ConcertoScreen;
+import top.gregtao.concerto.screen.widget.ModifiablePressableTextWidget;
+import top.gregtao.concerto.screen.widget.URLImageWidget;
+import top.gregtao.concerto.util.ConcertoRunner;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.time.LocalDateTime;
+
+public class KuGouMusicIndexScreen extends ConcertoScreen {
+    private URLImageWidget avatar;
+
+    private ModifiablePressableTextWidget vipStatusWidget;
+
+    public KuGouMusicIndexScreen(Screen parent) {
+        super(Text.translatable("concerto.screen.index.kugou"), parent);
+    }
+
+    @Override
+    protected void init() {
+        super.init();
+        this.addDrawableChild(ButtonWidget.builder(Text.translatable("concerto.screen.user"),
+                button -> MinecraftClient.getInstance().setScreen(new KuGouMusicUserScreen(this))
+        ).size(100, 20).position(this.width / 2 - 50, 40).build());
+        this.addDrawableChild(ButtonWidget.builder(Text.translatable("concerto.screen.search"),
+                button -> MinecraftClient.getInstance().setScreen(new KuGouMusicSearchScreen(this))
+        ).size(100, 20).position(this.width / 2 - 50, 65).build());
+
+        URL avatarUrl;
+        try {
+            avatarUrl = (!this.loggedIn() || KuGouMusicApiClient.LOCAL_USER.getAvatarUrl().isEmpty()) ? null :
+                    URI.create(KuGouMusicApiClient.LOCAL_USER.getAvatarUrl()).toURL();
+        } catch (MalformedURLException e) {
+            avatarUrl = null;
+        }
+        this.avatar = new URLImageWidget(64, 64, this.width / 2 - 32, 110,
+                avatarUrl == null ? null : avatarUrl.toString(), false);
+        ConcertoRunner.run(() -> {
+            this.avatar.loadImage(true, true);
+        });
+
+        if (loggedIn() && isVersionSame()) {
+            this.vipStatusWidget = this.addSelectableChild(new ModifiablePressableTextWidget(
+                    0, 0, 0, 0,
+                    Text.empty(),
+                    button -> {
+                        // 更新 VIP 状态
+                        KuGouMusicUser localUser = KuGouMusicApiClient.LOCAL_USER;
+                        if (localUser.isLoggedIn() && localUser.isVersionSame()) {
+                            Text tip;
+                            if (localUser.updateVIPStatus()) {
+                                tip = Text.translatable("concerto.screen.kugou.vip.update_success");
+                            } else {
+                                tip = Text.translatable("concerto.screen.kugou.vip.update_failed");
+                            }
+                            displayAlert(tip);
+                        }
+                    },
+                    textRenderer
+            ));
+        }
+    }
+
+    private boolean loggedIn() {
+        return KuGouMusicApiClient.LOCAL_USER.isLoggedIn();
+    }
+
+    private boolean isVersionSame() {
+        return KuGouMusicApiClient.LOCAL_USER.isVersionSame();
+    }
+
+    @Override
+    public void render(DrawContext matrices, int mouseX, int mouseY, float delta) {
+        super.render(matrices, mouseX, mouseY, delta);
+        Text text = this.loggedIn() ? Text.translatable("concerto.screen.kugou.welcome", KuGouMusicApiClient.LOCAL_USER.getUserName()) :
+                Text.translatable("concerto.screen.kugou.not_login");
+        matrices.drawCenteredTextWithShadow(this.textRenderer, text, this.width / 2, 90, 0xffffffff);
+
+        if (this.loggedIn()) {
+            boolean isVersionSame = isVersionSame();
+            int fontHeight = this.textRenderer.fontHeight;
+            int x = 5;
+            int bottom = this.height - 5;
+
+            Text currentVersion = Text.translatable("concerto.screen.kugou.version.current", getVersionName(KuGouMusicApiClient.LOCAL_USER.isLite()));
+            Text apiVersion = Text.translatable("concerto.screen.kugou.version.options", getVersionName(ClientConfig.INSTANCE.options.kuGouMusicLite));
+            Text versionStatus = isVersionSame ?
+                    Text.translatable("concerto.screen.kugou.version.correct") :
+                    Text.translatable("concerto.screen.kugou.version.warning");
+
+            // 避免 VIP 适用平台歧义, 只有版本匹配时才显示
+            if (isVersionSame) {
+                KuGouMusicUser.VIPLevel vipLevel = KuGouMusicApiClient.LOCAL_USER.getVipLevel();
+
+                LocalDateTime vipExpireTime = KuGouMusicApiClient.LOCAL_USER.getVipExpireTime();
+                if (vipLevel != KuGouMusicUser.VIPLevel.NONE && vipExpireTime != null) {
+                    Text expireTime = Text.translatable("concerto.screen.kugou.vip.expire_time", KuGouMusicUser.FORMATTER.format(vipExpireTime));
+                    bottom -= fontHeight;
+                    matrices.drawText(this.textRenderer, expireTime, x, bottom, 0xffffffff, true);
+                    bottom -= 1;
+                }
+
+                String levelPrefix = "concerto.screen.kugou.vip.level.";
+                String  levelText = Text.translatable(levelPrefix + vipLevel.name().toLowerCase()).getString();
+                Text vipStatus = Text.translatable("concerto.screen.kugou.vip.vip_level", levelText);
+                bottom -= fontHeight;
+                if (vipStatusWidget != null) {
+                    vipStatusWidget.setX(x);
+                    vipStatusWidget.setY(bottom);
+                    vipStatusWidget.setText(vipStatus);
+                    vipStatusWidget.render(matrices, mouseX, mouseY, delta);
+                }
+                bottom -= 1;
+            }
+
+            matrices.drawText(this.textRenderer, versionStatus, x, bottom - fontHeight, isVersionSame ? 5635925 : 16733525, true);
+            matrices.drawText(this.textRenderer, apiVersion, x, bottom - fontHeight * 2 - 1, 0xffffffff, true);
+            matrices.drawText(this.textRenderer, currentVersion, x, bottom - fontHeight * 3 - 2, 0xffffffff, true);
+        }
+
+        this.avatar.render(matrices, mouseX, mouseY, delta);
+    }
+
+    public String getVersionName(boolean isLite) {
+        return Text.translatable("concerto.screen.kugou.version." + (isLite ? "lite" : "normal")).getString();
+    }
+}

--- a/src/main/java/top/gregtao/concerto/screen/kugou/KuGouMusicLoginScreen.java
+++ b/src/main/java/top/gregtao/concerto/screen/kugou/KuGouMusicLoginScreen.java
@@ -1,0 +1,181 @@
+package top.gregtao.concerto.screen.kugou;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.text.Text;
+import top.gregtao.concerto.ConcertoClient;
+import top.gregtao.concerto.http.kugou.KuGouMusicApiClient;
+import top.gregtao.concerto.screen.ConcertoScreen;
+import top.gregtao.concerto.screen.login.CaptchaLoginScreen;
+import top.gregtao.concerto.screen.login.CookieLoginScreen;
+import top.gregtao.concerto.screen.login.PasswordLoginScreen;
+import top.gregtao.concerto.screen.login.QRCodeLoginScreen;
+import top.gregtao.concerto.util.Pair;
+import top.gregtao.concerto.util.QRCodeRenderer;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class KuGouMusicLoginScreen extends ConcertoScreen {
+
+    public static Text SOURCE_TEXT = Text.translatable("concerto.source.kugou_music");
+
+    public KuGouMusicLoginScreen(Screen parent) {
+        super(Text.literal(Text.translatable("concerto.screen.login").getString() + SOURCE_TEXT.getString()), parent);
+    }
+
+    @Override
+    protected void init() {
+        super.init();
+        this.addDrawableChild(ButtonWidget.builder(Text.translatable("concerto.screen.login.type.password"),
+                button -> MinecraftClient.getInstance().setScreen(this.passwordLogin())
+        ).size(100, 20).position(this.width / 2 - 50, 40).build());
+        this.addDrawableChild(ButtonWidget.builder(Text.translatable("concerto.screen.login.type.captcha"),
+                button -> MinecraftClient.getInstance().setScreen(this.captchaLogin())
+        ).size(100, 20).position(this.width / 2 - 50, 70).build());
+        this.addDrawableChild(ButtonWidget.builder(Text.translatable("concerto.screen.login.type.qrcode"),
+                button -> MinecraftClient.getInstance().setScreen(this.qrCodeLogin())
+        ).size(100, 20).position(this.width / 2 - 50, 100).build());
+        this.addDrawableChild(ButtonWidget.builder(Text.translatable("concerto.screen.login.type.cookie"),
+                button -> MinecraftClient.getInstance().setScreen(this.cookieLogin())
+        ).size(100, 20).position(this.width / 2 - 50, 130).build());
+    }
+
+    private static boolean loginChecker() {
+        return KuGouMusicApiClient.LOCAL_USER.isLoggedIn();
+    }
+
+    public PasswordLoginScreen passwordLogin() {
+        return new PasswordLoginScreen(
+                KuGouMusicLoginScreen::loginChecker,
+                (username, password) -> {
+                    try {
+                        Optional<Pair<Long, String>> optional = KuGouMusicApiClient.INSTANCE.login(username, password);
+                        if (optional.isPresent()) {
+                            Pair<Long, String> pair = optional.get();
+                            setCookies(pair.getFirst(), pair.getSecond());
+                            return Text.translatable("concerto.login.kugou.success");
+                        } else {
+                            return Text.translatable("concerto.login.kugou.failed");
+                        }
+                    } catch (Exception e) {
+                        return Text.translatable("concerto.login.kugou.error");
+                    }
+                },
+                SOURCE_TEXT,
+                this
+        );
+    }
+
+    public CaptchaLoginScreen captchaLogin() {
+        return new CaptchaLoginScreen(
+                phone -> {
+                    try {
+                        KuGouMusicApiClient.INSTANCE.sendPhoneCaptcha(phone);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                },
+                KuGouMusicLoginScreen::loginChecker,
+                (username, password) -> {
+                    try {
+                        Optional<Pair<Long, String>> result = KuGouMusicApiClient.INSTANCE.cellphoneLogin(username, password);
+                        if (result.isPresent()) {
+                            Pair<Long, String> pair = result.get();
+
+                            setCookies(pair.getFirst(), pair.getSecond());
+                            return Text.translatable("concerto.login.kugou.success");
+                        } else {
+                            return Text.translatable("concerto.login.kugou.failed");
+                        }
+                    } catch (Exception e) {
+                        return Text.translatable("concerto.login.kugou.error");
+                    }
+                },
+                SOURCE_TEXT,
+                this
+        );
+    }
+
+    public QRCodeLoginScreen qrCodeLogin() {
+        return new QRCodeLoginScreen(
+                () -> {
+                    try {
+                        return KuGouMusicApiClient.INSTANCE.generateQRCodeKey();
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                },
+                key -> QRCodeRenderer.generateQRCode(KuGouMusicApiClient.INSTANCE.getQRCodeLoginLink(key), 5),
+                key -> {
+                    try {
+                        Optional<JsonObject> optional = KuGouMusicApiClient.INSTANCE.getQRCodeStatus(key);
+                        Optional<JsonObject> dataOpt = optional.map(json -> json.getAsJsonObject("data"));
+                        Integer status = dataOpt.map(data -> data.get("status"))
+                                .map(JsonElement::getAsInt)
+                                .orElse(0);
+                        if (status == 1 || status == 2) {
+                            return QRCodeLoginScreen.Status.WAITING;
+                        } else if (status == 0) {
+                            return QRCodeLoginScreen.Status.EXPIRED;
+                        } else if (status == 4) {
+                            Long userId = dataOpt.map(data -> data.get("userid"))
+                                    .map(JsonElement::getAsLong)
+                                    .orElseThrow();
+
+                            String token = dataOpt.map(data -> data.get("token"))
+                                    .map(JsonElement::getAsString)
+                                    .orElseThrow();
+
+                            setCookies(userId, token);
+                            return QRCodeLoginScreen.Status.SUCCESS;
+                        } else {
+                            return QRCodeLoginScreen.Status.EMPTY;
+                        }
+                    } catch (Exception e) {
+                        ConcertoClient.LOGGER.error("Error in KuGou Music QR Login", e);
+                        throw new RuntimeException(e);
+                    }
+                },
+                110, 110,
+                SOURCE_TEXT,
+                this
+        );
+    }
+
+    public void setCookies(Long userId, String token) throws IOException, URISyntaxException {
+        KuGouMusicApiClient.LOCAL_USER.setUserId(userId);
+        KuGouMusicApiClient.INSTANCE.setCookies(
+                "https://www.kugou.com/",
+                new HashMap<>(Map.of(
+                        "userid", userId.toString(),
+                        "token", token
+                ))
+        );
+        KuGouMusicApiClient.LOCAL_USER.updateLoginStatus();
+        KuGouMusicApiClient.LOCAL_USER.updateVIPStatus();
+    }
+
+    public CookieLoginScreen cookieLogin() {
+        return new CookieLoginScreen(
+                () -> {
+                    boolean updated = KuGouMusicApiClient.LOCAL_USER.updateLoginStatus();
+                    if (updated) {
+                        KuGouMusicApiClient.LOCAL_USER.updateVIPStatus();
+                    }
+                    return updated;
+                },
+                List.of("https://www.kugou.com/"),
+                KuGouMusicApiClient.INSTANCE,
+                SOURCE_TEXT,
+                this
+        );
+    }
+}

--- a/src/main/java/top/gregtao/concerto/screen/kugou/KuGouMusicSearchScreen.java
+++ b/src/main/java/top/gregtao/concerto/screen/kugou/KuGouMusicSearchScreen.java
@@ -1,0 +1,207 @@
+package top.gregtao.concerto.screen.kugou;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.client.gui.widget.CyclingButtonWidget;
+import net.minecraft.client.gui.widget.TextFieldWidget;
+import net.minecraft.text.Text;
+import org.lwjgl.glfw.GLFW;
+import top.gregtao.concerto.ConcertoClient;
+import top.gregtao.concerto.api.WithMetaData;
+import top.gregtao.concerto.enums.SearchType;
+import top.gregtao.concerto.http.kugou.KuGouMusicApiClient;
+import top.gregtao.concerto.music.Music;
+import top.gregtao.concerto.music.list.KuGouMusicPlaylist;
+import top.gregtao.concerto.music.list.Playlist;
+import top.gregtao.concerto.player.MusicPlayer;
+import top.gregtao.concerto.screen.MusicInfoScreen;
+import top.gregtao.concerto.screen.PageScreen;
+import top.gregtao.concerto.screen.PlaylistPreviewScreen;
+import top.gregtao.concerto.screen.widget.ConcertoListWidget;
+import top.gregtao.concerto.screen.widget.MetadataListWidget;
+import top.gregtao.concerto.util.ConcertoRunner;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class KuGouMusicSearchScreen extends PageScreen {
+    public static String DEFAULT_KEYWORD = "";
+    private MetadataListWidget<Music> musicList;
+    private MetadataListWidget<KuGouMusicPlaylist> playlistList;
+    private MetadataListWidget<KuGouMusicPlaylist> albumList;
+    private Map<SearchType, ConcertoListWidget<?>> listWidgetsMap = new HashMap<>();
+    protected TextFieldWidget searchBox;
+    private ButtonWidget infoButton;
+    private SearchType searchType = SearchType.MUSIC;
+
+    private <T extends WithMetaData> MetadataListWidget<T> initListsWidget() {
+        return new MetadataListWidget<>(this.width, this.height - 75, 40, 18) {
+            @Override
+            public void onDoubleClicked(ConcertoListWidget<T>.Entry entry) {
+                try {
+                    switch (KuGouMusicSearchScreen.this.searchType) {
+                        case MUSIC: {
+                            MusicPlayer.INSTANCE.addMusicHere((Music) entry.item, true);
+                            break;
+                        }
+                        case PLAYLIST, ALBUM: {
+                            MinecraftClient.getInstance().setScreen(new PlaylistPreviewScreen((Playlist) entry.item, KuGouMusicSearchScreen.this));
+                            break;
+                        }
+                    }
+                } catch (ClassCastException e) {
+                    ConcertoClient.LOGGER.error(e.getMessage());
+                }
+            }
+        };
+    }
+
+    public KuGouMusicSearchScreen(Screen parent) {
+        super(Text.translatable("concerto.screen.search.kugou"), parent);
+    }
+
+    private void search(String keyword, int page) {
+        DEFAULT_KEYWORD = keyword;
+        if (keyword.isEmpty()) return;
+        ConcertoRunner.run(() -> {
+            switch (this.searchType) {
+                case MUSIC -> this.musicList.reset(KuGouMusicApiClient.INSTANCE.searchMusic(keyword, page), null);
+                case PLAYLIST -> this.playlistList.reset(KuGouMusicApiClient.INSTANCE.searchPlaylist(keyword, page), null);
+                case ALBUM -> this.albumList.reset(KuGouMusicApiClient.INSTANCE.searchAlbum(keyword, page), null);
+            }
+            this.listWidgetsMap.get(this.searchType).setScrollY(0);
+        });
+    }
+
+    private void toggleSearch() {
+        this.page = 0;
+        this.search(this.searchBox.getText(), 1);
+    }
+
+    private void updateSearchType(SearchType type) {
+        try {
+            this.remove(this.listWidgetsMap.get(this.searchType));
+        } catch (NullPointerException ignored) {}
+        this.addSelectableChild(this.listWidgetsMap.get(type));
+        this.searchType = type;
+        this.infoButton.active = type == SearchType.MUSIC;
+        this.toggleSearch();
+    }
+
+    @Override
+    public void onPageTurned(int page) {
+        this.search(this.searchBox.getText(), page + 1);
+    }
+
+    @Override
+    protected void init() {
+        super.init();
+        this.musicList = this.initListsWidget();
+        this.playlistList = this.initListsWidget();
+        this.albumList = this.initListsWidget();
+
+        this.listWidgetsMap = Map.of(
+                SearchType.MUSIC, this.musicList,
+                SearchType.PLAYLIST, this.playlistList,
+                SearchType.ALBUM, this.albumList
+        );
+
+        this.searchBox = new TextFieldWidget(this.textRenderer, this.width / 2 - 155, 17, 200, 20,
+                this.searchBox, Text.translatable("concerto.screen.search"));
+        this.addSelectableChild(this.searchBox);
+        this.addDrawableChild(this.searchBox);
+        this.searchBox.setText(DEFAULT_KEYWORD);
+
+        this.infoButton = ButtonWidget.builder(Text.translatable("concerto.screen.info"), button -> {
+            ConcertoListWidget<Music>.Entry entry = this.musicList.getSelectedOrNull();
+            if (entry != null) {
+                MinecraftClient.getInstance().setScreen(new MusicInfoScreen(entry.item, this));
+            }
+        }).position(this.width / 2 + 120, this.height - 30).size(50, 20).build();
+        this.addDrawableChild(this.infoButton);
+
+        this.updateSearchType(this.searchType);
+
+        this.addDrawableChild(ButtonWidget.builder(Text.translatable("concerto.screen.search"),
+                button -> this.toggleSearch()).position(this.width / 2 + 50, 17).size(52, 20).build());
+
+        this.addDrawableChild(CyclingButtonWidget.builder(SearchType::getName).values(SearchType.values()).initially(this.searchType).build(
+                this.width / 2 + 105, 17, 65, 20, Text.translatable("concerto.search_type"),
+                (widget, type) -> this.updateSearchType(type)));
+
+        this.addDrawableChild(ButtonWidget.builder(Text.translatable("concerto.screen.play"), button -> {
+            switch (this.searchType) {
+                case MUSIC: {
+                    ConcertoListWidget<Music>.Entry entry = this.musicList.getSelectedOrNull();
+                    if (entry != null) {
+                        MusicPlayer.INSTANCE.addMusicHere(entry.item, true);
+                    }
+                }
+                case PLAYLIST: {
+                    ConcertoListWidget<KuGouMusicPlaylist>.Entry entry = this.playlistList.getSelectedOrNull();
+                    if (entry != null) {
+                        MinecraftClient.getInstance().setScreen(new PlaylistPreviewScreen(entry.item, this));
+                    }
+                }
+                case ALBUM: {
+                    ConcertoListWidget<KuGouMusicPlaylist>.Entry entry = this.albumList.getSelectedOrNull();
+                    if (entry != null) {
+                        MinecraftClient.getInstance().setScreen(new PlaylistPreviewScreen(entry.item, this));
+                    }
+                }
+            }
+        }).position(this.width / 2 + 65, this.height - 30).size(50, 20).build());
+
+        this.addDrawableChild(ButtonWidget.builder(Text.translatable("concerto.screen.add"), button -> {
+            switch (this.searchType) {
+                case MUSIC: {
+                    ConcertoListWidget<Music>.Entry entry = this.musicList.getSelectedOrNull();
+                    if (entry != null) {
+                        MusicPlayer.INSTANCE.addMusic(entry.item);
+                    }
+                }
+                case PLAYLIST: {
+                    ConcertoListWidget<KuGouMusicPlaylist>.Entry entry = this.playlistList.getSelectedOrNull();
+                    if (entry != null) {
+                        MusicPlayer.INSTANCE.addMusic(() -> entry.item.getList(), () -> {});
+                    }
+                }
+                case ALBUM: {
+                    ConcertoListWidget<KuGouMusicPlaylist>.Entry entry = this.albumList.getSelectedOrNull();
+                    if (entry != null) {
+                        MusicPlayer.INSTANCE.addMusic(() -> entry.item.getList(), () -> {});
+                    }
+                }
+            }
+        }).position(this.width / 2 + 10, this.height - 30).size(50, 20).build());
+    }
+
+    @Override
+    public void render(DrawContext matrices, int mouseX, int mouseY, float delta) {
+        super.render(matrices, mouseX, mouseY, delta);
+        switch (this.searchType) {
+            case PLAYLIST -> this.playlistList.render(matrices, mouseX, mouseY, delta);
+            case MUSIC -> this.musicList.render(matrices, mouseX, mouseY, delta);
+            case ALBUM -> this.albumList.render(matrices, mouseX, mouseY, delta);
+        }
+    }
+
+    @Override
+    public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
+        if (super.keyPressed(keyCode, scanCode, modifiers)) {
+            return true;
+        }
+        if (keyCode == GLFW.GLFW_KEY_ENTER && this.searchBox.isSelected()) {
+            this.toggleSearch();
+            return true;
+        }
+        return this.searchBox.keyPressed(keyCode, scanCode, modifiers);
+    }
+
+    @Override
+    public boolean charTyped(char chr, int modifiers) {
+        return this.searchBox.charTyped(chr, modifiers);
+    }
+}

--- a/src/main/java/top/gregtao/concerto/screen/kugou/KuGouMusicUserScreen.java
+++ b/src/main/java/top/gregtao/concerto/screen/kugou/KuGouMusicUserScreen.java
@@ -1,0 +1,114 @@
+package top.gregtao.concerto.screen.kugou;
+
+import com.google.gson.JsonElement;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.text.Text;
+import top.gregtao.concerto.api.WithMetaData;
+import top.gregtao.concerto.config.ClientConfig;
+import top.gregtao.concerto.http.kugou.KuGouMusicApiClient;
+import top.gregtao.concerto.music.list.KuGouMusicPlaylist;
+import top.gregtao.concerto.music.list.Playlist;
+import top.gregtao.concerto.screen.PageScreen;
+import top.gregtao.concerto.screen.PlaylistPreviewScreen;
+import top.gregtao.concerto.screen.widget.ConcertoListWidget;
+import top.gregtao.concerto.screen.widget.MetadataListWidget;
+import top.gregtao.concerto.util.ConcertoRunner;
+
+import java.util.concurrent.CompletableFuture;
+
+public class KuGouMusicUserScreen extends PageScreen {
+
+    private MetadataListWidget<KuGouMusicPlaylist> playlistList;
+
+    private <T extends WithMetaData> MetadataListWidget<T> initWidget() {
+        return new MetadataListWidget<>(this.width, this.height - 55, 20, 18) {
+            @Override
+            public void onDoubleClicked(ConcertoListWidget<T>.Entry entry) {
+                MinecraftClient.getInstance().setScreen(new PlaylistPreviewScreen((Playlist) entry.item, KuGouMusicUserScreen.this));
+            }
+        };
+    }
+
+    public KuGouMusicUserScreen(Screen parent) {
+        super(Text.translatable("concerto.screen.user"), parent);
+    }
+
+    @Override
+    public void onPageTurned(int page) {
+        ConcertoRunner.run(() -> {
+            if (KuGouMusicApiClient.LOCAL_USER.updateLoginStatus()) {
+                this.playlistList.reset(KuGouMusicApiClient.LOCAL_USER.getUserPlaylists(page + 1), null);
+            }
+        });
+    }
+
+    private boolean loggedIn() {
+        return KuGouMusicApiClient.LOCAL_USER.isLoggedIn();
+    }
+
+    @Override
+    protected void init() {
+        super.init();
+        if (!this.loggedIn()) {
+            MinecraftClient.getInstance().setScreen(new KuGouMusicLoginScreen(null));
+        }
+        this.playlistList = this.initWidget();
+
+        this.onPageTurned(0);
+        this.addDrawableChild(this.playlistList);
+        this.addSelectableChild(this.playlistList);
+
+        if (ClientConfig.INSTANCE.options.kuGouMusicLite) {
+            this.addDrawableChild(ButtonWidget.builder(Text.translatable("concerto.screen.daily_vip"),
+                    button -> CompletableFuture.supplyAsync(
+                            () -> KuGouMusicApiClient.INSTANCE.receiveVip()
+                    ).thenAccept(jsonObject -> {
+                        String text = jsonObject.map(object -> object.get("error_code"))
+                                .map(JsonElement::getAsInt)
+                                .map(code -> {
+                                    switch (code) {
+                                        case 0 -> {
+                                            return "success";
+                                        }
+                                        case 131001 -> {
+                                            return "duplicate";
+                                        }
+                                        default -> {
+                                            return "failed";
+                                        }
+                                    }
+                                })
+                                .orElse("failed");
+
+                        displayAlert(Text.translatable("concerto.screen.daily_vip." + text));
+                    })).position(this.width / 2 - 10, this.height - 30).size(70, 20).build()
+            );
+        }
+
+        this.addDrawableChild(ButtonWidget.builder(Text.translatable("concerto.screen.play"), button -> {
+            ConcertoListWidget<KuGouMusicPlaylist>.Entry entry = this.playlistList.getSelectedOrNull();
+            if (entry != null) {
+                MinecraftClient.getInstance().setScreen(new PlaylistPreviewScreen(entry.item, this));
+            }
+        }).position(this.width / 2 + 65, this.height - 30).size(50, 20).build());
+
+        this.addDrawableChild(ButtonWidget.builder(Text.translatable("concerto.screen.logout"), button -> {
+            if (this.loggedIn()) {
+                KuGouMusicApiClient.LOCAL_USER.logout();
+            }
+            MinecraftClient.getInstance().setScreen(new KuGouMusicLoginScreen(this));
+        }).position(this.width / 2 + 120, this.height - 30).size(50, 20).build());
+    }
+
+    @Override
+    public void render(DrawContext matrices, int mouseX, int mouseY, float delta) {
+        super.render(matrices, mouseX, mouseY, delta);
+        if (!this.loggedIn()) {
+            matrices.drawCenteredTextWithShadow(this.textRenderer, Text.translatable("concerto.screen.kugou.not_login"),
+                    this.width / 2, this.height / 2, 0xffffffff);
+        }
+    }
+}

--- a/src/main/java/top/gregtao/concerto/screen/widget/ModifiablePressableTextWidget.java
+++ b/src/main/java/top/gregtao/concerto/screen/widget/ModifiablePressableTextWidget.java
@@ -1,0 +1,35 @@
+package top.gregtao.concerto.screen.widget;
+
+import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.widget.PressableTextWidget;
+import net.minecraft.text.Style;
+import net.minecraft.text.Text;
+import net.minecraft.text.Texts;
+import net.minecraft.util.math.MathHelper;
+
+public class ModifiablePressableTextWidget extends PressableTextWidget {
+    private TextRenderer textRenderer;
+    private Text text;
+    private Text hoverText;
+
+    public ModifiablePressableTextWidget(int x, int y, int width, int height, Text text, PressAction onPress, TextRenderer textRenderer) {
+        super(x, y, width, height, text, onPress, textRenderer);
+        this.textRenderer = textRenderer;
+        this.text = text;
+        this.hoverText = Texts.setStyleIfAbsent(text.copy(), Style.EMPTY.withUnderline(true));
+    }
+
+    @Override
+    public void renderWidget(DrawContext context, int mouseX, int mouseY, float deltaTicks) {
+        Text text = this.isSelected() ? this.hoverText : this.text;
+        context.drawTextWithShadow(this.textRenderer, text, this.getX(), this.getY(), 16777215 | MathHelper.ceil(this.alpha * 255.0F) << 24);
+    }
+
+    public void setText(Text text) {
+        this.text = text;
+        this.hoverText = Texts.setStyleIfAbsent(text.copy(), Style.EMPTY.withUnderline(true));
+        this.setWidth(this.textRenderer.getWidth(text));
+        this.setHeight(this.textRenderer.fontHeight);
+    }
+}

--- a/src/main/java/top/gregtao/concerto/util/ConcertoOptions.java
+++ b/src/main/java/top/gregtao/concerto/util/ConcertoOptions.java
@@ -126,6 +126,18 @@ public class ConcertoOptions {
                 value -> this.config.options.coverImgRotate = value,
                 () -> this.config.options.coverImgRotate
         ));
+
+        this.updaters.add(new SingleBooleanOption(
+                "kugouIsLite",
+                value -> this.config.options.kuGouMusicLite = value,
+                () -> this.config.options.kuGouMusicLite
+        ));
+
+        this.updaters.add(new SingleBooleanOption(
+                "autoGetKuGouDailyVIP",
+                value -> this.config.options.autoGetKuGouDailyVIP = value,
+                () -> this.config.options.autoGetKuGouDailyVIP
+        ));
     }
 
     public SimpleOption<?>[] getOptions() {

--- a/src/main/java/top/gregtao/concerto/util/LyricsUtil.java
+++ b/src/main/java/top/gregtao/concerto/util/LyricsUtil.java
@@ -1,0 +1,102 @@
+package top.gregtao.concerto.util;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class LyricsUtil {
+
+    private final static Gson GSON = new Gson();
+
+    public static Pair<String, String> krcToLrc(String krc) {
+        String[] lines = krc.split("\n|\r|\r\n");
+        List<Pair<String, String>> pairList = new ArrayList<>();
+        for (String line : lines) {
+            line = line.trim();
+            if (!line.isEmpty()) {
+                String[] parts = line.split("]");
+                if (parts.length >= 1) {
+                    String timePart = parts[0].substring(1);
+                    if (parts.length > 1) {
+                        String lyricPart = parts[parts.length - 1].trim();
+                        if (!lyricPart.isEmpty()) {
+                            pairList.add(Pair.of(timePart, lyricPart));
+                        }
+                    } else {
+                        pairList.add(Pair.of(timePart, ""));
+                    }
+                }
+            }
+        }
+
+        List<String> transLyricStr = new ArrayList<>();
+        List<String> mainLyric = new ArrayList<>();
+        List<String> transLyric = new ArrayList<>();
+        int i = 0;
+        for (Pair<String, String> pair : pairList) {
+            String first = pair.getFirst();
+            if (first.startsWith("language")) {
+                String[] strings = first.split(":");
+                if (strings.length == 2) {
+                    transLyricStr = getTransLyric(strings[1]);
+                }
+            } else {
+                String second = pair.getSecond();
+                if (second != null && first.matches("\\d+,.+")){
+                    String[] strings = first.split(",");
+                    String time = strings[0];
+                    String formattedTime = formatTime(Integer.parseInt(time));
+                    String lyric = second.replaceAll("<\\d+,[^>]+>", "");
+                    mainLyric.add(formattedTime + lyric);
+
+                    if (transLyricStr.size() > i) {
+                        transLyric.add(formattedTime + transLyricStr.get(i));
+                    }
+                    i++;
+                } else {
+                    String string = "[" + first + second + "]";
+                    mainLyric.add(string);
+                    transLyric.add(string);
+                }
+            }
+        }
+
+        return Pair.of(String.join("\n", mainLyric), String.join("\n", transLyric));
+    }
+
+    public static List<String> getTransLyric(String language) {
+        String json = TextUtil.fromBase64(language);
+        JsonObject jsonObject = GSON.fromJson(json, JsonObject.class);
+
+        return Optional.ofNullable(jsonObject)
+                .map(obj -> obj.getAsJsonArray("content"))
+                .flatMap(arr -> arr.asList().stream()
+                        .filter(el -> Optional.ofNullable(el.getAsJsonObject())
+                                .map(object -> object.get("type"))
+                                .map(type -> type.getAsInt() == 1)
+                                .orElse(false)
+                        )
+                        .findFirst()
+                )
+                .map(JsonElement::getAsJsonObject)
+                .map(lyric -> lyric.getAsJsonArray("lyricContent"))
+                .map(arr -> arr.asList().stream()
+                        .map(JsonElement::getAsJsonArray)
+                        .map(timeAndLyric -> timeAndLyric.isEmpty() ? "" : timeAndLyric.get(0).getAsString())
+                        .collect(Collectors.toList())
+                )
+                .orElse(new ArrayList<>());
+    }
+
+    public static String formatTime(int ms) {
+        int minutes = ms / 60000;
+        int seconds = (ms % 60000) / 1000;
+        int hundredths = (ms % 1000) / 10;
+        return String.format("[%02d:%02d.%02d]", minutes, seconds, hundredths);
+    }
+}

--- a/src/main/java/top/gregtao/concerto/util/MathUtil.java
+++ b/src/main/java/top/gregtao/concerto/util/MathUtil.java
@@ -25,6 +25,12 @@ public class MathUtil {
         return formattedTime(parseIntOrElse(timestamp, 0));
     }
 
+    public static String formattedTime(long timestamp) {
+        Date date = new Date(timestamp);
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
+        return dateFormat.format(date);
+    }
+
     public static <T> int lowerBound(ArrayList<T> a, T key, Comparator<? super T> c) {
         return lowerBound(a, 0, a.size() - 1, key, c);
     }

--- a/src/main/java/top/gregtao/concerto/util/Optionals.java
+++ b/src/main/java/top/gregtao/concerto/util/Optionals.java
@@ -1,0 +1,28 @@
+package top.gregtao.concerto.util;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+public class Optionals {
+
+    @SafeVarargs
+    public static <T, R> Optional<R> firstOf(Optional<T> opt, Function<? super T, ? extends R>... mapper) {
+        if (opt.isEmpty()) return Optional.empty();
+        for (Function<? super T, ? extends R> func : mapper) {
+            R res = func.apply(opt.get());
+            if (res != null) return Optional.of(res);
+        }
+        return Optional.empty();
+    }
+
+    @SafeVarargs
+    public static <T, R> Optional<R> flatFirstOf(Optional<T> opt, Function<? super T, ? extends Optional<R>>... mapper) {
+        if (opt.isEmpty()) return Optional.empty();
+        for (Function<? super T, ? extends Optional<R>> func : mapper) {
+            Optional<R> res = func.apply(opt.get());
+            if (res.isPresent()) return res;
+        }
+        return Optional.empty();
+    }
+
+}

--- a/src/main/java/top/gregtao/concerto/util/QRCodeRenderer.java
+++ b/src/main/java/top/gregtao/concerto/util/QRCodeRenderer.java
@@ -1,6 +1,7 @@
 package top.gregtao.concerto.util;
 
 import com.google.zxing.BarcodeFormat;
+import com.google.zxing.EncodeHintType;
 import com.google.zxing.WriterException;
 import com.google.zxing.common.BitMatrix;
 import com.google.zxing.qrcode.QRCodeWriter;
@@ -10,6 +11,7 @@ import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.Map;
 
 public class QRCodeRenderer {
 
@@ -29,6 +31,41 @@ public class QRCodeRenderer {
             for (int x = 0; x < width; x++) {
                 for (int y = 0; y < height; y++) {
                     image.setRGB(x, y, matrix.get(x, y) ? BLACK : WHITE);
+                }
+            }
+            ImageIO.write(image, "png", stream);
+            return stream.toByteArray();
+        } catch (IOException | WriterException e) {
+            ConcertoClient.LOGGER.error("Error while generating QR Code", e);
+            return new byte[]{};
+        }
+    }
+
+    public static byte[] generateQRCode(String text, int margin) {
+        try (ByteArrayOutputStream stream = new ByteArrayOutputStream()) {
+            BitMatrix matrix = new QRCodeWriter().encode(
+                    text,
+                    BarcodeFormat.QR_CODE,
+                    0,
+                    0
+                    ,Map.of(
+                            EncodeHintType.MARGIN, 0
+                    )
+            );
+            int qrWidth = matrix.getWidth();
+            int qrHeight = matrix.getHeight();
+            int width = qrWidth + margin * 2;
+            int height = qrHeight + margin * 2;
+            BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+            for (int x = 0; x < width; x++) {
+                for (int y = 0; y < height; y++) {
+                    int xi = x - margin;
+                    int yi = y - margin;
+                    if (xi < 0 || xi >= qrWidth || yi < 0 || yi >= qrHeight) {
+                        image.setRGB(x, y, WHITE);
+                        continue;
+                    }
+                    image.setRGB(x, y, matrix.get(xi, yi) ? BLACK : WHITE);
                 }
             }
             ImageIO.write(image, "png", stream);

--- a/src/main/java/top/gregtao/concerto/util/RandomUtil.java
+++ b/src/main/java/top/gregtao/concerto/util/RandomUtil.java
@@ -1,0 +1,18 @@
+package top.gregtao.concerto.util;
+
+import java.util.Random;
+
+public class RandomUtil {
+    private static final String KEY_STRING = "1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    private static final char[] KEY_ARRAY = KEY_STRING.toCharArray();
+    private static final Random RANDOM = new Random();
+
+    public static String randomString(int len) {
+        StringBuilder sb = new StringBuilder(len);
+        for (int i = 0; i < len; i++) {
+            int ceil = (int) Math.ceil((KEY_ARRAY.length - 1) * RANDOM.nextDouble());
+            sb.append(KEY_ARRAY[ceil]);
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/resources/assets/concerto/lang/en_us.json
+++ b/src/main/resources/assets/concerto/lang/en_us.json
@@ -1,6 +1,7 @@
 {
   "concerto.source.netease_cloud": "Netease Cloud",
   "concerto.source.qq_music": "QQ Music",
+  "concerto.source.kugou_music": "KuGou Music",
   "concerto.source.bilibili": "Bilibili",
   "concerto.source.local_file": "Local File",
   "concerto.source.internet": "Internet Resources",
@@ -99,6 +100,10 @@
   "concerto.screen.audition.permission_denied": "You don't have such permissions",
   "concerto.screen.daily_recommendation": "Daily Recommendation",
   "concerto.screen.copy_link": "Copy link",
+  "concerto.screen.daily_vip": "Daily VIP",
+  "concerto.screen.daily_vip.success": "Successfully got Daily VIP!",
+  "concerto.screen.daily_vip.duplicate": "You've got Daily VIP today!",
+  "concerto.screen.daily_vip.failed": "Failed to get Daily VIP!",
 
   "concerto.screen.add.local_file": "Local File:",
   "concerto.screen.add.local_file.folder": "Local Folder:",
@@ -107,6 +112,7 @@
   "concerto.screen.add.netease_cloud.playlist": "Netease Playlist:",
   "concerto.screen.add.netease_cloud.album": "Netease Album:",
   "concerto.screen.add.qq": "QQ Music (MID):",
+  "concerto.screen.add.kugou": "KuGou Music (EMixSongID):",
   "concerto.screen.add.bilibili": "Bilibili (BVID):",
 
   "concerto.screen.login": "Login: ",
@@ -133,11 +139,30 @@
   "concerto.screen.search.163": "NeteaseCloud Search",
   "concerto.screen.index.qq": "QQ Music Index",
   "concerto.screen.search.qq": "QQ Music Search",
+  "concerto.screen.index.kugou": "KuGou Music Index",
+  "concerto.screen.search.kugou": "KuGou Music Search",
   "concerto.screen.user": "User",
   "concerto.screen.163.welcome": "Welcome, %s, this is NeteaseCloud Music",
   "concerto.screen.163.not_login": "You haven't logged in to NeteaseCloud Music",
   "concerto.screen.qq.welcome": "Welcome, %s, this is QQ Music",
   "concerto.screen.qq.not_login": "You haven't logged in to QQ Music",
+  "concerto.screen.kugou.welcome": "Welcome, %s, this is KuGou Music",
+  "concerto.screen.kugou.not_login": "You haven't logged in to KuGou Music",
+  "concerto.screen.kugou.version.correct": "Version matched!",
+  "concerto.screen.kugou.version.warning": "Incompatible versions! Please re-login or change the configuration version!",
+  "concerto.screen.kugou.version.normal": "Normal",
+  "concerto.screen.kugou.version.lite": "Lite",
+  "concerto.screen.kugou.version.current": "Current User Version: %s",
+  "concerto.screen.kugou.version.options": "API Version: %s",
+  "concerto.screen.kugou.vip.vip_level": "VIP Level: %s (Click to update)",
+  "concerto.screen.kugou.vip.expire_time": "VIP Expire Time: %s",
+  "concerto.screen.kugou.vip.update_success": "VIP Status Updated!",
+  "concerto.screen.kugou.vip.update_failed": "VIP Status Update Failed!",
+  "concerto.screen.kugou.vip.level.none": "No VIP or VIP Expired",
+  "concerto.screen.kugou.vip.level.vip": "VIP",
+  "concerto.screen.kugou.vip.level.s_vip": "Super VIP",
+  "concerto.screen.kugou.vip.level.busi_s_vip": "Lite VIP",
+  "concerto.screen.kugou.vip.level.busi_t_vip": "Ting VIP",
   "concerto.screen.login.type.qrcode.qq": "QQ QR Code",
   "concerto.screen.login.type.qrcode.wechat": "WeChat QR Code",
   "concerto.screen.general_list": "General Playlist",
@@ -181,6 +206,10 @@
   "concerto.login.163.failed.501": "Your phone number haven't been registered",
   "concerto.login.163.failed.502": "Incorrect password",
   "concerto.login.163.failed.503": "Incorrect code (captcha)",
+
+  "concerto.login.kugou.success": "Successfully logged in to KuGou Music",
+  "concerto.login.kugou.failed": "Failed to log in",
+  "concerto.login.kugou.error": "Error occurs while trying to login",
 
   "concerto.hotkey": "Concerto Hotkeys",
   "concerto.hotkey.general_music_list": "Open General playlist",
@@ -275,5 +304,8 @@
   "concerto.options.align": "%s: %s",
   "concerto.options.align.left": "Left",
   "concerto.options.align.center": "Center",
-  "concerto.options.align.right": "Right"
+  "concerto.options.align.right": "Right",
+
+  "concerto.options.kugouIsLite": "Use KuGou Lite API",
+  "concerto.options.autoGetKuGouDailyVIP": "Auto Get KuGou Daily VIP"
 }

--- a/src/main/resources/assets/concerto/lang/zh_cn.json
+++ b/src/main/resources/assets/concerto/lang/zh_cn.json
@@ -2,6 +2,7 @@
   "concerto.source.netease_cloud": "网易云",
   "concerto.source.qq_music": "QQ音乐",
   "concerto.source.bilibili": "哔哩哔哩",
+  "concerto.source.kugou_music": "酷狗音乐",
   "concerto.source.local_file": "本地文件",
   "concerto.source.internet": "网络资源",
 
@@ -98,6 +99,10 @@
   "concerto.screen.confirmation": "接受音乐分享",
   "concerto.screen.audition.permission_denied": "你没有权限",
   "concerto.screen.daily_recommendation": "每日推荐",
+  "concerto.screen.daily_vip": "领取每日VIP",
+  "concerto.screen.daily_vip.success": "领取今日 VIP 成功！",
+  "concerto.screen.daily_vip.duplicate": "今日已领取过 VIP！",
+  "concerto.screen.daily_vip.failed": "领取今日 VIP 失败！",
 
   "concerto.screen.add.local_file": "本地文件:",
   "concerto.screen.add.local_file.folder": "本地文件夹:",
@@ -106,6 +111,7 @@
   "concerto.screen.add.netease_cloud.playlist": "网易云歌单:",
   "concerto.screen.add.netease_cloud.album": "网易云专辑:",
   "concerto.screen.add.qq": "QQ音乐（MID）:",
+  "concerto.screen.add.kugou": "酷狗音乐（EMixSongID）:",
   "concerto.screen.add.bilibili": "B站（BV号）",
 
   "concerto.screen.login": "登录到: ",
@@ -132,11 +138,30 @@
   "concerto.screen.search.163": "网易云音乐 搜索",
   "concerto.screen.index.qq": "QQ音乐 索引",
   "concerto.screen.search.qq": "QQ音乐 搜索",
+  "concerto.screen.index.kugou": "酷狗音乐 索引",
+  "concerto.screen.search.kugou": "酷狗音乐 搜索",
   "concerto.screen.user": "用户",
   "concerto.screen.163.welcome": "%s 您好！欢迎使用网易云音乐",
   "concerto.screen.163.not_login": "你尚未登录网易云音乐账户",
   "concerto.screen.qq.welcome": "%s 您好！欢迎使用QQ音乐",
   "concerto.screen.qq.not_login": "你尚未登录QQ音乐账户",
+  "concerto.screen.kugou.welcome": "%s 您好！欢迎使用酷狗音乐",
+  "concerto.screen.kugou.not_login": "你尚未登录酷狗音乐账户",
+  "concerto.screen.kugou.version.correct": "版本已匹配！",
+  "concerto.screen.kugou.version.warning": "版本不匹配！请重新登录或修改配置中的接口版本！",
+  "concerto.screen.kugou.version.normal": "普通版",
+  "concerto.screen.kugou.version.lite": "概念版",
+  "concerto.screen.kugou.version.current": "当前用户版本: %s",
+  "concerto.screen.kugou.version.options": "接口版本: %s",
+  "concerto.screen.kugou.vip.vip_level": "VIP 等级: %s (点击刷新)",
+  "concerto.screen.kugou.vip.expire_time": "VIP 到期时间: %s",
+  "concerto.screen.kugou.vip.update_success": "VIP 状态更新成功！",
+  "concerto.screen.kugou.vip.update_failed": "VIP 状态更新失败！",
+  "concerto.screen.kugou.vip.level.none": "无 VIP 或 VIP 已过期",
+  "concerto.screen.kugou.vip.level.vip": "豪华 VIP",
+  "concerto.screen.kugou.vip.level.s_vip": "超级 VIP",
+  "concerto.screen.kugou.vip.level.busi_s_vip": "概念版 VIP",
+  "concerto.screen.kugou.vip.level.busi_t_vip": "畅听 VIP",
   "concerto.screen.login.type.qrcode.qq": "QQ 二维码登录",
   "concerto.screen.login.type.qrcode.wechat": "微信 二维码登录",
   "concerto.screen.general_list": "全局歌单",
@@ -181,6 +206,10 @@
   "concerto.login.163.failed.501": "该手机号码尚未被注册",
   "concerto.login.163.failed.502": "密码或手机号/邮箱错误",
   "concerto.login.163.failed.503": "验证码错误",
+
+  "concerto.login.kugou.success": "成功登录了酷狗音乐",
+  "concerto.login.kugou.failed": "登录失败",
+  "concerto.login.kugou.error": "尝试登录时发生错误",
 
   "concerto.hotkey": "Concerto 热键",
   "concerto.hotkey.general_music_list": "打开全局歌单",
@@ -275,5 +304,8 @@
   "concerto.options.align": "%s: %s",
   "concerto.options.align.left": "左",
   "concerto.options.align.center": "中",
-  "concerto.options.align.right": "右"
+  "concerto.options.align.right": "右",
+
+  "concerto.options.kugouIsLite": "使用酷狗概念版接口",
+  "concerto.options.autoGetKuGouDailyVIP": "自动领取酷狗每日VIP"
 }


### PR DESCRIPTION
除正常的音乐搜索、登录等功能外，添加了三个配置项
- 客户端
    - kuGouMusicLite：控制酷狗音乐是否使用概念版 API。概念版和普通版歌单、用户信息互通，但 token 不互通，概念版的 VIP 和畅听 VIP 无法在普通版使用
    - autoGetKuGouDailyVIP：是否开启自动领取酷狗每日畅听 VIP，只会在使用概念版 API 时生效，每次客户端重新加载资源时尝试领取畅听 VIP
- 服务端
    - kuGouMusicLite：在专用服务器模组不会加载客户端配置，所以在服务端添加该配置项以确定服务端的 token 使用的 API 版本